### PR TITLE
`pub parse`, `Ref` fix

### DIFF
--- a/bauble/src/lib.rs
+++ b/bauble/src/lib.rs
@@ -16,7 +16,7 @@ pub use value::{
 };
 
 use parse::Values;
-fn parse(src: &str) -> Option<Values> {
+pub fn parse(src: &str) -> Option<Values> {
     use ariadne::{Color, Label, Report, ReportKind, Source};
     use chumsky::Parser;
 

--- a/bauble/src/value/mod.rs
+++ b/bauble/src/value/mod.rs
@@ -387,6 +387,7 @@ impl<C: AssetContext> Symbols<C> {
 
         item.into_owned()
             .to_asset()
+            .map(|_| path.to_string())
             .ok_or(ConversionError::ExpectedAsset.span(path.span))
     }
 


### PR DESCRIPTION
- Makes `parse` public, which I needed for enum checking
- Fixes `Ref` not containing the full path, which I needed so I could find the asset it's referencing
