### PR TITLE
Make chumsky a hard dependency

### DIFF
--- a/bauble/Cargo.toml
+++ b/bauble/Cargo.toml
@@ -15,7 +15,7 @@ hashbrown = ["dep:hashbrown"]
 [dependencies]
 ariadne = "0.1.5"
 bauble_macros = { path = "../bauble_macros" }
-chumsky = "1.0.0-alpha.3"
+chumsky = "=1.0.0-alpha.3"
 hashbrown = { version = "0.14", optional = true }
 impl-trait-for-tuples = "0.2.2"
 indexmap = "1.9.1"


### PR DESCRIPTION
This is added because chumsky only updates [alpha version](https://doc.rust-lang.org/cargo/reference/resolver.html#pre-releases) between breaking changes.