### PR TITLE
`rename` and `ignore` attributes

### DIFF
--- a/bauble_macro_util/src/lib.rs
+++ b/bauble_macro_util/src/lib.rs
@@ -754,7 +754,7 @@ pub fn derive_bauble_derive_input(
                     )
                 }
                 false => (
-                    quote! { ::bauble::TypeInfo::new(#path, stringify!(#ident)) },
+                    quote! { ::bauble::TypeInfo::new(#path, stringify!(#name)) },
                     quote! {
                         ::std::result::Result::Ok(match value {
                             ::bauble::Value::Struct(type_info, fields) => {

--- a/bauble_macro_util/src/lib.rs
+++ b/bauble_macro_util/src/lib.rs
@@ -817,7 +817,7 @@ pub fn derive_bauble_derive_input(
                                     Err(meta.error("path must be an identifier"))?
                                 };
 
-                                if found.insert(ident.to_string()) {
+                                if !found.insert(ident.to_string()) {
                                     Err(meta.error("duplicate attribute"))?
                                 }
 

--- a/bauble_macro_util/src/lib.rs
+++ b/bauble_macro_util/src/lib.rs
@@ -746,7 +746,8 @@ pub fn derive_bauble_derive_input(
                     (
                         quote! {
                             ::bauble::TypeInfo::Flatten(&[
-                                &<#flattened_ty as ::bauble::FromBauble>::INFO,
+                                &<#flattened_ty as ::bauble::FromBauble<#lifetime, #allocator>>
+                                    ::INFO,
                             ])
                         },
                         quote! { ::std::result::Result::Ok( { #case } ) },


### PR DESCRIPTION
- `rename` attribute that overrides the name used in `FromBauble::INFO`
- `ignore` attribute that prevents attributed enum variants from being deserialized
- Fixes a bug where flattened structs with custom allocators wouldn't compile
- Fixes a bug where attributes on variants wouldn't compile