### PR TITLE
Always ref type

### DIFF
--- a/bauble/src/lib.rs
+++ b/bauble/src/lib.rs
@@ -46,7 +46,7 @@ pub fn simple_convert(src: &str) -> Result<Vec<Object>, Spanned<ConversionError>
 
     let ctx = value::NoChecks;
 
-    convert_values("".to_string(), values, &value::Symbols::new(&ctx))
+    convert_values("".to_string(), values, &value::Symbols::new(&ctx), src)
 }
 
 pub fn convert(
@@ -57,5 +57,5 @@ pub fn convert(
     let values =
         parse(src).ok_or(ConversionError::ParseError.spanned(SimpleSpan::new(0, src.len())))?;
 
-    convert_values(file_name.into(), values, &value::Symbols::new(&ctx))
+    convert_values(file_name.into(), values, &value::Symbols::new(&ctx), src)
 }

--- a/bauble/src/main.rs
+++ b/bauble/src/main.rs
@@ -41,7 +41,7 @@ fn main() {
 
     let ctx = NoChecks;
 
-    let objects = convert_values("test.rsn".to_string(), values, &Symbols::new(&ctx));
+    let objects = convert_values("test.rsn".to_string(), values, &Symbols::new(&ctx), &src);
 
     match objects {
         Ok(objects) => {

--- a/bauble/src/value/mod.rs
+++ b/bauble/src/value/mod.rs
@@ -819,7 +819,7 @@ fn convert_object<C: AssetContext>(
     symbols: &Symbols<C>,
     add_value: &mut impl FnMut(Val) -> Val,
 ) -> Result<Object> {
-    let value = convert_value(value, symbols, add_value, false)?;
+    let value = convert_value(value, symbols, add_value, true)?;
 
     Ok(create_object(path, name, value))
 }

--- a/bauble_macro_util/src/lib.rs
+++ b/bauble_macro_util/src/lib.rs
@@ -584,6 +584,8 @@ pub fn derive_bauble_derive_input(
     let mut rename = None;
     // Attributes that are not type-level
     let mut attributes = vec![];
+    // Set this typeinfo to always be a referece.
+    let mut always_ref = false;
 
     // Parse attributes
     for attr in &ast.attrs {
@@ -672,6 +674,19 @@ pub fn derive_bauble_derive_input(
 
                     if !meta.input.is_empty() && !meta.input.peek(Token![,]) {
                         Err(meta.error("unexpected token after allocator"))?
+                    }
+
+                    Ok(())
+                }
+                "always_ref" => {
+                    if flatten {
+                        Err(meta.error("duplicate `always_ref` attribute"))?
+                    }
+
+                    always_ref = true;
+
+                    if !meta.input.is_empty() && !meta.input.peek(Token![,]) {
+                        Err(meta.error("unexpected token after always_ref"))?
                     }
 
                     Ok(())
@@ -979,6 +994,14 @@ pub fn derive_bauble_derive_input(
             }
         }
     });
+
+    let type_info = if always_ref {
+        quote! {
+            (#type_info).with_always_ref()
+        }
+    } else {
+        type_info
+    };
 
     // Assemble the implementation
     quote! {

--- a/bauble_macro_util/src/lib.rs
+++ b/bauble_macro_util/src/lib.rs
@@ -605,6 +605,9 @@ pub fn derive_bauble_derive_input(
 
             match ident.to_string().as_str() {
                 "flatten" => {
+                    if always_ref {
+                        Err(meta.error("`flatten` and `always_ref` are incompatible"))?
+                    }
                     if flatten {
                         Err(meta.error("duplicate `flatten` attribute"))?
                     }
@@ -680,6 +683,9 @@ pub fn derive_bauble_derive_input(
                 }
                 "always_ref" => {
                     if flatten {
+                        Err(meta.error("`flatten` and `always_ref` are incompatible"))?
+                    }
+                    if always_ref {
                         Err(meta.error("duplicate `always_ref` attribute"))?
                     }
 

--- a/bauble_macro_util/src/lib.rs
+++ b/bauble_macro_util/src/lib.rs
@@ -584,7 +584,7 @@ pub fn derive_bauble_derive_input(
     let mut rename = None;
     // Attributes that are not type-level
     let mut attributes = vec![];
-    // Set this typeinfo to always be a referece.
+    // Set this typeinfo to always be a reference.
     let mut always_ref = false;
 
     // Parse attributes

--- a/bauble_macro_util/src/lib.rs
+++ b/bauble_macro_util/src/lib.rs
@@ -598,7 +598,7 @@ pub fn derive_bauble_derive_input(
                 .to_compile_error();
         }
 
-        match attr.parse_nested_meta(|meta| {
+        let nested_meta = attr.parse_nested_meta(|meta| {
             let Some(ident) = meta.path.get_ident() else {
                 Err(meta.error("path must be an identifier"))?
             };
@@ -696,7 +696,9 @@ pub fn derive_bauble_derive_input(
                     Ok(())
                 }
             }
-        }) {
+        });
+
+        match nested_meta {
             Ok(()) => (),
             Err(err) => return err.to_compile_error(),
         }


### PR DESCRIPTION
Fixes some padding issues, so this closes #17 .

Adds Ariadne error printing for the value conversion step.

Adds a marker for the `FromBauble` type that the type should always be parsed as a reference.