### PR TITLE
Typed objects

### DIFF
--- a/bauble/src/parse/value.rs
+++ b/bauble/src/parse/value.rs
@@ -315,6 +315,7 @@ impl Object {
 
 fn indented_display_value(
     ident: &Ident,
+    type_path: Option<&Spanned<Path>>,
     object: &Object,
     indent: usize,
     f: &mut fmt::Formatter<'_>,
@@ -330,14 +331,26 @@ fn indented_display_value(
         write!(f, "{i}")?;
     }
 
-    write!(f, "{ident} = ")?;
+    write!(f, "{ident}")?;
+
+    if let Some(ty) = type_path {
+        write!(f, ": {ty}")?;
+    }
+
+    write!(f, " = ")?;
     object.value.indented_display(indent, f)
+}
+
+#[derive(Debug)]
+pub struct Binding {
+    pub type_path: Option<Spanned<Path>>,
+    pub object: Object,
 }
 
 #[derive(Debug)]
 pub struct Values {
     pub uses: Vec<Use>,
-    pub values: IndexMap<Ident, Object>,
+    pub values: IndexMap<Ident, Binding>,
     pub copies: IndexMap<Ident, Object>,
 }
 
@@ -351,13 +364,13 @@ impl Values {
         }
 
         for (ident, object) in self.values.iter() {
-            indented_display_value(ident, object, indent, f)?;
+            indented_display_value(ident, object.type_path.as_ref(), &object.object, indent, f)?;
             writeln!(f, "\n")?;
         }
 
         for (ident, object) in self.copies.iter() {
             write!(f, "{i}copy ")?;
-            indented_display_value(ident, object, indent, f)?;
+            indented_display_value(ident, None, object, indent, f)?;
             writeln!(f, "\n")?;
         }
 

--- a/bauble/src/value/asset_context.rs
+++ b/bauble/src/value/asset_context.rs
@@ -157,6 +157,17 @@ pub enum TypeKind {
     Any(OwnedTypeInfo),
 }
 
+impl TypeKind {
+    pub fn type_info(&self) -> OwnedTypeInfo {
+        match self {
+            TypeKind::Struct(s) => s.type_info.clone(),
+            TypeKind::EnumVariant(e) => e.enum_type_info.clone(),
+            TypeKind::BitField(b) => b.type_info.clone(),
+            TypeKind::Any(t) => t.clone(),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum Reference {
     Any(OwnedTypeInfo),

--- a/bauble/src/value/asset_context.rs
+++ b/bauble/src/value/asset_context.rs
@@ -31,7 +31,12 @@ pub enum OwnedTypeInfo {
         always_ref: bool,
     },
     Kind(ValueKind),
-    Flatten(Vec<OwnedTypeInfo>),
+    Flatten {
+        module: String,
+        ident: String,
+        always_ref: bool,
+        types: Vec<OwnedTypeInfo>,
+    },
 }
 
 impl Display for OwnedTypeInfo {
@@ -39,7 +44,7 @@ impl Display for OwnedTypeInfo {
         match self {
             OwnedTypeInfo::Kind(kind) => write!(f, "{kind}"),
             OwnedTypeInfo::Path { module, ident, .. } => write!(f, "{module}::{ident}"),
-            OwnedTypeInfo::Flatten(types) => {
+            OwnedTypeInfo::Flatten { types, .. } => {
                 write!(
                     f,
                     "({})",
@@ -72,7 +77,13 @@ pub enum TypeInfo<'a> {
         always_ref: bool,
     },
     Kind(ValueKind),
-    Flatten(&'a [&'a TypeInfo<'a>]),
+    Flatten {
+        module: &'a str,
+        ident: &'a str,
+        always_ref: bool,
+
+        types: &'a [&'a TypeInfo<'a>],
+    },
 }
 
 impl<'a> TypeInfo<'a> {
@@ -91,6 +102,17 @@ impl<'a> TypeInfo<'a> {
                 ident,
                 always_ref: true,
             },
+            TypeInfo::Flatten {
+                module,
+                ident,
+                types,
+                ..
+            } => TypeInfo::Flatten {
+                module,
+                ident,
+                always_ref: true,
+                types,
+            },
             s => s,
         }
     }
@@ -107,9 +129,17 @@ impl<'a> TypeInfo<'a> {
                 always_ref: *always_ref,
             },
             &TypeInfo::Kind(kind) => OwnedTypeInfo::Kind(kind),
-            TypeInfo::Flatten(types) => {
-                OwnedTypeInfo::Flatten(types.iter().map(|&ty| ty.to_owned()).collect())
-            }
+            TypeInfo::Flatten {
+                module,
+                ident,
+                always_ref,
+                types,
+            } => OwnedTypeInfo::Flatten {
+                types: types.iter().map(|&ty| ty.to_owned()).collect(),
+                module: module.to_string(),
+                ident: ident.to_string(),
+                always_ref: *always_ref,
+            },
         }
     }
 
@@ -124,7 +154,26 @@ impl<'a> TypeInfo<'a> {
                 },
             ) => module == m && ident == i,
             (TypeInfo::Kind(kind), OwnedTypeInfo::Kind(other_kind)) => kind == other_kind,
-            (TypeInfo::Flatten(types), other) => types.iter().any(|ty| ty.contains(other)),
+            (
+                TypeInfo::Flatten {
+                    types,
+                    module,
+                    ident,
+                    ..
+                },
+                other,
+            ) => {
+                (if let OwnedTypeInfo::Path {
+                    module: m,
+                    ident: i,
+                    ..
+                } = other
+                {
+                    module == m && ident == i
+                } else {
+                    false
+                }) || types.iter().any(|ty| ty.contains(other))
+            }
             _ => false,
         }
     }
@@ -206,10 +255,11 @@ impl Reference {
     pub fn get_module(&self) -> Option<Cow<str>> {
         match self {
             Reference::Any(type_info) => match type_info {
-                OwnedTypeInfo::Path { module, ident, .. } => {
+                OwnedTypeInfo::Path { module, ident, .. }
+                | OwnedTypeInfo::Flatten { module, ident, .. } => {
                     Some(Cow::Owned(format!("{module}::{ident}")))
                 }
-                OwnedTypeInfo::Kind(_) | OwnedTypeInfo::Flatten(_) => None,
+                OwnedTypeInfo::Kind(_) => None,
             },
             Reference::Specific { module, .. } => module.as_deref().map(Cow::Borrowed),
         }

--- a/bauble/src/value/mod.rs
+++ b/bauble/src/value/mod.rs
@@ -128,6 +128,9 @@ impl Value {
             OwnedTypeInfo::Path {
                 always_ref: true,
                 ..
+            } | OwnedTypeInfo::Flatten {
+                always_ref: true,
+                ..
             }
         )
     }

--- a/bauble/src/value/mod.rs
+++ b/bauble/src/value/mod.rs
@@ -168,6 +168,14 @@ pub struct Object {
     pub value: Val,
 }
 
+impl Object {
+    pub fn value_type(&self) -> OwnedTypeInfo {
+        self.type_path
+            .clone()
+            .unwrap_or_else(|| self.value.value.type_info())
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ConversionError {
     ModuleNotFound,

--- a/bauble/src/value/mod.rs
+++ b/bauble/src/value/mod.rs
@@ -162,7 +162,8 @@ impl Value {
 #[derive(Debug)]
 pub struct Object {
     pub object_path: AssetPath,
-    pub type_path: TypePath,
+    /// Optionally explicit type path, otherwise derive from value.
+    pub type_path: Option<TypePath>,
     pub path: String,
     pub value: Val,
 }
@@ -524,7 +525,7 @@ pub fn convert_values<C: AssetContext>(
             )
             .and_then(|mut object| {
                 if let Some(type_path) = &value.1.type_path {
-                    object.type_path = symbols.resolve_type(type_path)?.type_info();
+                    object.type_path = Some(symbols.resolve_type(type_path)?.type_info());
                 }
                 Ok(object)
             })
@@ -879,7 +880,7 @@ fn create_object(path: &str, name: &str, value: Val) -> Object {
     Object {
         // TODO: Create an object path.
         object_path: name.to_string(),
-        type_path: value.value.type_info(),
+        type_path: None,
         path: path.to_string(),
         value,
     }

--- a/bauble/src/value/mod.rs
+++ b/bauble/src/value/mod.rs
@@ -514,7 +514,21 @@ pub fn convert_values<C: AssetContext>(
     let parsed_objects = values
         .values
         .iter()
-        .map(|value| convert_object(&path, &value.0.value, value.1, &symbols, &mut add_value))
+        .map(|value| {
+            convert_object(
+                &path,
+                &value.0.value,
+                &value.1.object,
+                &symbols,
+                &mut add_value,
+            )
+            .and_then(|mut object| {
+                if let Some(type_path) = &value.1.type_path {
+                    object.type_path = symbols.resolve_type(type_path)?.type_info();
+                }
+                Ok(object)
+            })
+        })
         .collect::<Vec<_>>();
     {
         use ariadne::{Color, Label, Report, ReportKind, Source};

--- a/bauble_macro_util/src/lib.rs
+++ b/bauble_macro_util/src/lib.rs
@@ -777,10 +777,15 @@ pub fn derive_bauble_derive_input(
 
                     (
                         quote! {
-                            ::bauble::TypeInfo::Flatten(&[
-                                &<#flattened_ty as ::bauble::FromBauble<#lifetime, #allocator>>
-                                    ::INFO,
-                            ])
+                            ::bauble::TypeInfo::Flatten {
+                                types: &[
+                                    &<#flattened_ty as ::bauble::FromBauble<#lifetime, #allocator>>
+                                        ::INFO,
+                                ],
+                                module: #path,
+                                ident: stringify!(#name),
+                                always_ref: false,
+                            }
                         },
                         quote! { ::std::result::Result::Ok( { #case } ) },
                     )
@@ -935,9 +940,14 @@ pub fn derive_bauble_derive_input(
             match flatten {
                 true => (
                     quote! {
-                        ::bauble::TypeInfo::Flatten(&[
-                            #(&<#flattened_tys as ::bauble::FromBauble<#lifetime, #allocator>>::INFO,)*
-                        ])
+                        ::bauble::TypeInfo::Flatten {
+                            types: &[
+                                #(&<#flattened_tys as ::bauble::FromBauble<#lifetime, #allocator>>::INFO,)*
+                            ],
+                            module: #path,
+                            ident: stringify!(#name),
+                            always_ref: false,
+                        }
                     },
                     quote! {
                         ::std::result::Result::Ok(


### PR DESCRIPTION
Adds functionality to have an explicit type for a top level object.

i.e

```rust
foo: test_crate::Foo = [1, 2, 3, 4]
```
where foo might implement flatten to an array.