### PR TITLE
Bauble default

### DIFF
--- a/bauble/src/context.rs
+++ b/bauble/src/context.rs
@@ -154,11 +154,11 @@ impl BaubleContextBuilder {
 
     /// # Panics
     ///
-    /// Panics if `TypeRegistry::validate` is false.
+    /// Panics if `TypeRegistry::validate(false)` returns false.
     pub fn build(self) -> BaubleContext {
-        self.registry
-            .validate(false)
-            .expect("The type system should be valid");
+        if let Err(e) = self.registry.validate(false) {
+            panic!("Type system error: {e}");
+        }
         let mut root_node = CtxNode::new(TypePath::empty());
         for (id, path) in self.default_uses.0 {
             root_node.add_node(id.borrow()).reference.redirect = Some(path);

--- a/bauble/src/context.rs
+++ b/bauble/src/context.rs
@@ -156,7 +156,10 @@ impl BaubleContextBuilder {
     ///
     /// Panics if `TypeRegistry::validate` is false.
     pub fn build(self) -> BaubleContext {
-        assert!(self.registry.validate(), "The type system should be valid");
+        assert!(
+            self.registry.validate(false),
+            "The type system should be valid"
+        );
         let mut root_node = CtxNode::new(TypePath::empty());
         for (id, path) in self.default_uses.0 {
             root_node.add_node(id.borrow()).reference.redirect = Some(path);
@@ -407,6 +410,16 @@ pub struct BaubleContext {
     files: Vec<(TypePath, Source)>,
 
     retry_files: Vec<FileId>,
+}
+
+impl From<TypeRegistry> for BaubleContext {
+    fn from(registry: TypeRegistry) -> Self {
+        BaubleContextBuilder {
+            registry,
+            default_uses: DefaultUses::default(),
+        }
+        .build()
+    }
 }
 
 fn preprocess_path(path: TypePath<&str>) -> TypePath<&str> {

--- a/bauble/src/context.rs
+++ b/bauble/src/context.rs
@@ -156,10 +156,9 @@ impl BaubleContextBuilder {
     ///
     /// Panics if `TypeRegistry::validate` is false.
     pub fn build(self) -> BaubleContext {
-        assert!(
-            self.registry.validate(false),
-            "The type system should be valid"
-        );
+        self.registry
+            .validate(false)
+            .expect("The type system should be valid");
         let mut root_node = CtxNode::new(TypePath::empty());
         for (id, path) in self.default_uses.0 {
             root_node.add_node(id.borrow()).reference.redirect = Some(path);

--- a/bauble/src/lib.rs
+++ b/bauble/src/lib.rs
@@ -54,7 +54,7 @@ macro_rules! bauble_test {
             let mut ctx = $crate::BaubleContextBuilder::new();
             $(ctx.register_type::<$ty, _>();)*
             let mut ctx = ctx.build();
-            assert!(ctx.type_registry().validate(true), "Invalid type registry");
+            ctx.type_registry().validate(true).expect("Invalid type registry");
             let file_path = $crate::path::TypePath::new("test").unwrap();
             ctx.register_file(file_path, format!("\n{}\n", $source));
 

--- a/bauble/src/lib.rs
+++ b/bauble/src/lib.rs
@@ -20,7 +20,8 @@ pub use traits::{
 pub use types::path;
 pub use value::{
     Attributes, ConversionError, DisplayConfig, FieldsKind, IndentedDisplay, Object,
-    PrimitiveValue, UnspannedVal, Val, Value, display_formatted,
+    PrimitiveValue, SpannedValue, UnspannedVal, Val, Value, ValueContainer, ValueTrait,
+    display_formatted,
 };
 
 #[doc(hidden)]
@@ -53,6 +54,7 @@ macro_rules! bauble_test {
             let mut ctx = $crate::BaubleContextBuilder::new();
             $(ctx.register_type::<$ty, _>();)*
             let mut ctx = ctx.build();
+            assert!(ctx.type_registry().validate(true), "Invalid type registry");
             let file_path = $crate::path::TypePath::new("test").unwrap();
             ctx.register_file(file_path, format!("\n{}\n", $source));
 

--- a/bauble/src/lib.rs
+++ b/bauble/src/lib.rs
@@ -20,7 +20,7 @@ pub use traits::{
 pub use types::path;
 pub use value::{
     Attributes, ConversionError, DisplayConfig, FieldsKind, IndentedDisplay, Object,
-    PrimitiveValue, Val, Value, display_formatted,
+    PrimitiveValue, UnspannedVal, Val, Value, display_formatted,
 };
 
 #[doc(hidden)]

--- a/bauble/src/parse/parser.rs
+++ b/bauble/src/parse/parser.rs
@@ -499,13 +499,12 @@ pub fn parser<'a>() -> impl Parser<'a, ParserSource<'a>, ParseValues, Extra<'a>>
             // - `| Path::B`
             // - `|`
             let path_or = path_p
-                .map_with(|path, e| path.spanned(e.span()))
                 .separated_by(just('|').padded_by(comments))
                 .allow_leading()
                 .at_least(2)
                 .collect()
                 .or(just('|')
-                    .ignore_then(path_p.map_with(|p, e| p.spanned(e.span())).or_not())
+                    .ignore_then(path_p.or_not())
                     .map(|p| p.into_iter().collect()))
                 .map(Value::Or);
 

--- a/bauble/src/parse/parser.rs
+++ b/bauble/src/parse/parser.rs
@@ -406,6 +406,10 @@ pub fn parser<'a>() -> impl Parser<'a, ParserSource<'a>, ParseValues, Extra<'a>>
                 .map(|_| Value::Primitive(PrimitiveValue::Bool(true)))
                 .or(just("false").map(|_| Value::Primitive(PrimitiveValue::Bool(false))));
 
+            let unit = just("()").map(|_| Value::Primitive(PrimitiveValue::Unit));
+
+            let null = just("null").map(|_| Value::Primitive(PrimitiveValue::Null));
+
             let transparent = object
                 .clone()
                 .map(|v| Value::Transparent(Box::new(v)))
@@ -533,6 +537,8 @@ pub fn parser<'a>() -> impl Parser<'a, ParserSource<'a>, ParseValues, Extra<'a>>
             let no_type = |t| (None, t);
             let value = choice((
                 bool_.map(no_type),
+                unit.map(no_type),
+                null.map(no_type),
                 num.map(no_type),
                 string.map(no_type),
                 reference.map(no_type),

--- a/bauble/src/parse/parser.rs
+++ b/bauble/src/parse/parser.rs
@@ -563,10 +563,9 @@ pub fn parser<'a>() -> impl Parser<'a, ParserSource<'a>, ParseValues, Extra<'a>>
                         .boxed(),
                 )
                 .map(
-                    #[expect(clippy::type_complexity)]
                     |(attributes, spanned): (
                         _,
-                        Spanned<(Option<Path>, crate::Value<ParseVal, Path, Path>)>,
+                        Spanned<(Option<Path>, crate::Value<ParseVal>)>,
                     )| {
                         let Spanned {
                             span,

--- a/bauble/src/traits.rs
+++ b/bauble/src/traits.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, collections::HashMap, fmt::Display};
 
 use crate::{
-    CustomError, Val, Value,
+    CustomError, SpannedValue, Val, Value,
     context::BaubleContext,
     error::{BaubleError, ErrorMsg, Level},
     path::{TypePath, TypePathElem},

--- a/bauble/src/traits.rs
+++ b/bauble/src/traits.rs
@@ -1,7 +1,5 @@
 use std::{borrow::Cow, collections::HashMap, fmt::Display};
 
-use indexmap::IndexMap;
-
 use crate::{
     CustomError, Val, Value,
     context::BaubleContext,
@@ -490,10 +488,7 @@ macro_rules! impl_tuple {
                     kind: types::TypeKind::Tuple(
                         types::UnnamedFields::default().with_required([
                             $(
-                                FieldType {
-                                    id: registry.get_or_register_type::<$ident, A>(),
-                                    extra: IndexMap::new(),
-                                }
+                                FieldType::from(registry.get_or_register_type::<$ident, A>())
                             ),+
                         ]),
                     ),
@@ -550,10 +545,7 @@ impl<'a, A: BaubleAllocator<'a>, T: Bauble<'a, A>, const N: usize> Bauble<'a, A>
                 ..Default::default()
             },
             kind: types::TypeKind::Array(types::ArrayType {
-                ty: FieldType {
-                    id: inner,
-                    extra: IndexMap::new(),
-                },
+                ty: FieldType::from(inner),
                 len: Some(N),
             }),
         }
@@ -606,10 +598,7 @@ impl<'a, A: BaubleAllocator<'a>, T: Bauble<'a, A>> Bauble<'a, A> for Option<T> {
             types::Variant::explicit(
                 TypePathElem::new("Some").unwrap(),
                 types::Fields::Unnamed(types::UnnamedFields {
-                    required: vec![types::FieldType {
-                        id: inner,
-                        extra: Default::default(),
-                    }],
+                    required: vec![types::FieldType::from(inner)],
                     ..Default::default()
                 }),
             ),
@@ -685,10 +674,7 @@ impl<'a, T: Bauble<'a>> Bauble<'a> for Vec<T> {
                 ..Default::default()
             },
             kind: types::TypeKind::Array(types::ArrayType {
-                ty: types::FieldType {
-                    id: inner,
-                    extra: Default::default(),
-                },
+                ty: types::FieldType::from(inner),
                 len: None,
             }),
         }
@@ -723,10 +709,7 @@ impl<'a, T: Bauble<'a>> Bauble<'a> for Box<T> {
                 ..Default::default()
             },
             kind: types::TypeKind::Array(types::ArrayType {
-                ty: types::FieldType {
-                    id: inner,
-                    extra: Default::default(),
-                },
+                ty: types::FieldType::from(inner),
                 len: None,
             }),
         }
@@ -759,14 +742,8 @@ macro_rules! impl_map {
                         ..Default::default()
                     },
                     kind: types::TypeKind::Map(types::MapType {
-                        key: FieldType {
-                            id: key,
-                            extra: IndexMap::new(),
-                        },
-                        value: FieldType {
-                            id: value,
-                            extra: IndexMap::new(),
-                        },
+                        key: FieldType::from(key),
+                        value: FieldType::from(value),
                         len: None,
                     }),
                 }

--- a/bauble/src/types.rs
+++ b/bauble/src/types.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
+    fmt::Display,
     ptr::{DynMetadata, Pointee},
 };
 
@@ -165,6 +166,39 @@ pub enum TypeSystemError<'a> {
     },
     InstantiableErrors,
     ConstructInequality(UnspannedVal, UnspannedVal),
+}
+
+impl Display for TypeSystemError<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TypeSystemError::ToBeAssigned(items) => {
+                write!(f, "The following types haven't been assigned to ")?;
+                for (i, (ty_id, ty)) in items.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "`{ty}` ({ty_id:?})")?;
+                }
+
+                Ok(())
+            }
+            TypeSystemError::NotInstantiable { ty_id, ty } => write!(
+                f,
+                "The type `{ty}` ({ty_id:?}) is expected to be instantiable, but it isn't."
+            ),
+            TypeSystemError::InstantiableErrors => write!(
+                f,
+                "Errors while trying to read default instantiated objects"
+            ),
+            TypeSystemError::ConstructInequality(a, b) => {
+                write!(
+                    f,
+                    "The constructed instantiated type, and the value read from the instantiated \
+                    value formatted as text are not equal.\nInstantiated: {a:#?}\nRead: {b:#?}"
+                )
+            }
+        }
+    }
 }
 
 impl TypeRegistry {

--- a/bauble/src/value/convert.rs
+++ b/bauble/src/value/convert.rs
@@ -674,6 +674,13 @@ where
         };
 
         let value = match (&ty.kind, &value.value) {
+            (_, Value::Primitive(PrimitiveValue::Null)) => {
+                if ty.meta.nullable {
+                    Value::Primitive(PrimitiveValue::Null)
+                } else {
+                    Err(ConversionError::NotNullable(*ty_id).spanned(span))?
+                }
+            }
             (types::TypeKind::Tuple(fields), Value::Tuple(values)) => {
                 Value::Tuple(parse_unnamed!(fields, values))
             }

--- a/bauble/src/value/display.rs
+++ b/bauble/src/value/display.rs
@@ -279,6 +279,7 @@ where
                 super::PrimitiveValue::Str(v) => w.debug_fmt(v),
                 super::PrimitiveValue::Bool(v) => w.fmt(v),
                 super::PrimitiveValue::Unit => w.write("()"),
+                super::PrimitiveValue::Null => w.write("null"),
                 // `Raw` is a bit annoying to handle here, since we don't know how it
                 // was originally expressed. So we need to check:
                 // 1. Can it be displayed as a literal raw, i.e `#some_raw`

--- a/bauble/src/value/error.rs
+++ b/bauble/src/value/error.rs
@@ -70,6 +70,7 @@ pub enum ConversionError {
         ty: TypeId,
     },
     RefError(Box<RefError>),
+    NotNullable(TypeId),
     ExpectedExactType {
         expected: TypeId,
         got: Option<TypeId>,
@@ -143,6 +144,10 @@ impl BaubleError for Spanned<ConversionError> {
                 RefKind::Type => "Failed to resolve type",
                 RefKind::Any => "Failed to resolve path",
             }),
+            ConversionError::NotNullable(ty) => Cow::Owned(format!(
+                "The type `{}` is not nullable",
+                types.key_type(*ty).meta.path
+            )),
             ConversionError::ExpectedExactType { expected, .. } => Cow::Owned(format!(
                 "Expected the type `{}`",
                 types.key_type(*expected).meta.path
@@ -612,6 +617,7 @@ impl BaubleError for Spanned<ConversionError> {
 
                 return errs;
             }
+            ConversionError::NotNullable(_) => Cow::Borrowed("This value is `null`"),
             ConversionError::ExpectedExactType { expected, got } => {
                 let s = if let Some(got) = got {
                     format!(

--- a/bauble/src/value/mod.rs
+++ b/bauble/src/value/mod.rs
@@ -457,6 +457,7 @@ pub enum PrimitiveValue {
     Str(String),
     Bool(bool),
     Unit,
+    Null,
     Raw(String),
 }
 
@@ -490,6 +491,7 @@ impl<T: ValueTrait> Value<T> {
                 PrimitiveValue::Bool(_) => types::Primitive::Bool,
                 PrimitiveValue::Unit => types::Primitive::Unit,
                 PrimitiveValue::Raw(_) => types::Primitive::Raw,
+                PrimitiveValue::Null => return None,
             }),
             _ => None,
         }

--- a/bauble_macro_util/src/lib.rs
+++ b/bauble_macro_util/src/lib.rs
@@ -296,7 +296,7 @@ impl ContainerAttrs {
                     }
                     "nullable" => {
                         if !kind.is_type() {
-                            Err(meta.error("The `bounds` attribute can only be used on types"))?
+                            Err(meta.error("The `nullable` attribute can only be used on types"))?
                         }
                         if this.nullable.is_some() {
                             Err(meta.error("Duplicate `nullable` attribute"))?

--- a/bauble_macros/src/lib.rs
+++ b/bauble_macros/src/lib.rs
@@ -17,6 +17,10 @@ use proc_macro::TokenStream;
 /// - `bounds`: Adds extra bounds to the `Bauble` implementation.
 /// - `from`: Parse this type as if it was flattening to the specified type.
 ///   Specified like `from = T` and this type has to implement `From<T>`.
+/// - `nullable`: Mark this type as nullable, so it can parse from `null` values.
+///   This will by default use the types `Default` implementation which only
+///   works with the default allocator, but a certain value can be specified like
+///   `nullable = |allocator| unsafe { allocator.wrap(some_expr()) }`
 ///
 /// # Container or type attributes
 ///
@@ -31,6 +35,7 @@ use proc_macro::TokenStream;
 /// - `validate`: Adds extra validation to this type or variant. Expects a function
 ///   like `fn(&Val, &TypeRegistry) -> Result<(), ConversionError>`. Can either
 ///   be a defined function, or a closure.
+/// - `value_default`: Used to give the bauble type a default.
 ///
 /// # Only container attributes
 ///
@@ -54,6 +59,7 @@ use proc_macro::TokenStream;
 /// - `attribute`: This field is instead deserialized from bauble attributes. By
 ///   doing `attribute = <ident>` it can be assigned to read from a specific
 ///   attribute. By default it uses the field's name.
+/// - `value_default`: Used to give the field type a default in the bauble type system.
 #[proc_macro_derive(Bauble, attributes(bauble))]
 pub fn derive(input: TokenStream) -> TokenStream {
     derive_bauble(input.into()).into()


### PR DESCRIPTION
Adds optional default `Value`s for the bauble types. This also adds an `UnspannedVal`, which is what it's name says a `Val`, but without span information. Which is useful when we're generating bauble values and not loading from a text file.

To not have to have too many generic parameters on the `Value` enum I created the trait `ValueTrait` and `ValueContainer`, and we now use those trait's associated types instead. Which also meant some refactoring in `convert.rs`.

`ValueTrait` is implemented for values which have decided inner types. So we can use it to know what `Value` it contains.

`ValueContainer` is used for values which can contain one or multiple `ValueTrait`s. All types that implement `ValueTrait` implement `ValueContainer`.

I added a way for types to declare themselves as nullable, and a keyword `null`. Which bauble will allow that type to parse from if it's nullable. This is useful for references where it's not obvious what the default value should be. Since the default has to be created at type construction.