### PR TITLE
Default/nullable bauble value fixes

### DIFF
--- a/bauble/src/traits.rs
+++ b/bauble/src/traits.rs
@@ -796,10 +796,7 @@ impl<'a, A: BaubleAllocator<'a>, T: Bauble<'a, A> + enumset::EnumSetType> Bauble
                 ..Default::default()
             },
             kind: types::TypeKind::Array(types::ArrayType {
-                ty: FieldType {
-                    id: registry.get_or_register_type::<T, A>(),
-                    extra: IndexMap::new(),
-                },
+                ty: registry.get_or_register_type::<T, A>().into(),
                 len: None,
             }),
         }

--- a/bauble/src/types.rs
+++ b/bauble/src/types.rs
@@ -762,7 +762,7 @@ impl TypeRegistry {
             return Some(UnspannedVal {
                 ty: ty_id,
                 value: crate::Value::Primitive(crate::PrimitiveValue::Null),
-                // TODO: We probably want to include attributes here?
+                // Null values don't have attributes.
                 attributes: crate::Attributes::default(),
             });
         }

--- a/bauble/src/types.rs
+++ b/bauble/src/types.rs
@@ -758,6 +758,15 @@ impl TypeRegistry {
             return Some(default.clone().with_type(ty_id));
         }
 
+        if ty.meta.nullable {
+            return Some(UnspannedVal {
+                ty: ty_id,
+                value: crate::Value::Primitive(crate::PrimitiveValue::Null),
+                // TODO: We probably want to include attributes here?
+                attributes: crate::Attributes::default(),
+            });
+        }
+
         let construct_unnamed = |fields: &UnnamedFields| {
             fields
                 .required
@@ -829,7 +838,8 @@ impl TypeRegistry {
                 Primitive::Str => crate::PrimitiveValue::Str(String::new()),
                 Primitive::Bool => crate::PrimitiveValue::Bool(false),
                 Primitive::Unit => crate::PrimitiveValue::Unit,
-                Primitive::Raw => crate::PrimitiveValue::Raw(String::new()),
+                // We have no idea at this point what these should look like since it's user defined.
+                Primitive::Raw => return None,
             }),
             TypeKind::Transparent(ty) => {
                 let inner = self.key_type(*ty);

--- a/bauble/src/value/convert.rs
+++ b/bauble/src/value/convert.rs
@@ -674,12 +674,8 @@ where
         };
 
         let value = match (&ty.kind, &value.value) {
-            (_, Value::Primitive(PrimitiveValue::Null)) => {
-                if ty.meta.nullable {
-                    Value::Primitive(PrimitiveValue::Null)
-                } else {
-                    Err(ConversionError::NotNullable(*ty_id).spanned(span))?
-                }
+            (_, Value::Primitive(PrimitiveValue::Null)) if ty.meta.nullable => {
+                Value::Primitive(PrimitiveValue::Null)
             }
             (types::TypeKind::Tuple(fields), Value::Tuple(values)) => {
                 Value::Tuple(parse_unnamed!(fields, values))
@@ -963,6 +959,9 @@ where
                 // Try again as if it wasn't a transparent value.
                 extra_attributes.extend(&attributes, &meta);
                 return extra_attributes.convert_with(value, meta.reborrow(), expected_type);
+            }
+            (_, Value::Primitive(PrimitiveValue::Null)) => {
+                Err(ConversionError::NotNullable(*ty_id).spanned(span))?
             }
             _ => Err(expected_err())?,
         };


### PR DESCRIPTION
- Don't allow null values to have attributes.
- Correct default instantiation of "nullable" types.
- Correctly fail to instantiate raw values.
- Fix handling of null values for transparent types and enums.
- Allow passing a custom default to the bauble macro, to be used instead of `core::default::Default`.