### PR TITLE
Adding cursory documentation to Bauble

### DIFF
--- a/bauble/src/context.rs
+++ b/bauble/src/context.rs
@@ -31,7 +31,7 @@ pub struct PathReference {
 }
 
 impl PathReference {
-    /// Construicts an empty path reference.
+    /// Constructs an empty path reference.
     pub fn empty() -> Self {
         Self {
             ty: None,

--- a/bauble/src/error.rs
+++ b/bauble/src/error.rs
@@ -7,14 +7,19 @@ use crate::{
     context::{BaubleContext, BaubleContextCache},
 };
 
+/// A custom error message.
 #[derive(Clone, Debug, PartialEq)]
 pub struct CustomError {
+    /// The message to be displayed with the error.
     pub message: Cow<'static, str>,
+    /// The level of the error.
     pub level: Level,
+    /// Various additional diagnostics, highlighting areas of code.
     pub labels: Vec<(Spanned<Cow<'static, str>>, Level)>,
 }
 
 impl CustomError {
+    #[allow(missing_docs)]
     pub fn new(s: impl Into<Cow<'static, str>>) -> Self {
         Self {
             message: s.into(),
@@ -23,21 +28,30 @@ impl CustomError {
         }
     }
 
+    #[allow(missing_docs)]
     pub fn with_level(mut self, level: Level) -> Self {
         self.level = level;
         self
     }
 
+    /// Highlights a span of code with an accompanying diagnostic message with a diagnostic relevance of `level`.
+    #[allow(missing_docs)]
     pub fn with_label(mut self, s: Spanned<impl Into<Cow<'static, str>>>, level: Level) -> Self {
         self.labels.push((s.map(|s| s.into()), level));
         self
     }
 
+    /// Highlights a span of code with an accompanying message.
+    ///
+    /// Shorthand for [`with_label`](Self::with_label) with an error level.
+    #[allow(missing_docs)]
     pub fn with_err_label(self, s: Spanned<impl Into<Cow<'static, str>>>) -> Self {
         self.with_label(s, Level::Error)
     }
 }
 
+/// A level for diagnostics.
+#[allow(missing_docs)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Level {
     Info,
@@ -65,23 +79,34 @@ impl Level {
 
 pub type ErrorMsg = Spanned<Cow<'static, str>>;
 
+/// A common trait implemented by various types used for diagnostics in Bauble.
 pub trait BaubleError: 'static {
+    /// The level of the diagnostic.
+    ///
+    /// By default, this is [`Error`](Level::Error)
     fn level(&self) -> Level {
         Level::Error
     }
 
+    /// Can this diagnostic be ignored?
+    ///
+    /// By default, anything at a level of [`Error`](Level::Error) can not be ignored.
     fn can_ignore(&self) -> bool {
         !matches!(self.level(), Level::Error)
     }
 
+    /// A more general and easily readable diagnostic message.
     fn msg_general(&self, ctx: &BaubleContext) -> ErrorMsg;
 
+    /// A specific diagnostic message divided into multiple parts.
     fn msgs_specific(&self, ctx: &BaubleContext) -> Vec<(ErrorMsg, Level)>;
 
+    /// Optionally provide a help for how to fix the diagnostic in case of an error or warning.
     fn help(&self, _ctx: &BaubleContext) -> Option<Cow<'static, str>> {
         None
     }
 
+    /// Produces a [`Report`] from the diagnostic.
     fn report(&self, ctx: &BaubleContext) -> Report<'_, Span> {
         let msg = self.msg_general(ctx);
         let mut report =
@@ -131,20 +156,26 @@ impl<B: BaubleError> BaubleError for Box<B> {
     }
 }
 
+/// Maintains various amounts of errors produced by Bauble.
 pub struct BaubleErrors(Vec<Box<dyn BaubleError>>);
 
 impl BaubleErrors {
+    #[allow(missing_docs)]
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
+
+    /// Creates an empty instance of `Self`.
     pub fn empty() -> Self {
         Self(Vec::new())
     }
 
+    /// Extends `self` with all errors from `other`.
     pub fn extend(&mut self, other: BaubleErrors) {
         self.0.extend(other.0);
     }
 
+    /// Appends `error` onto `self`.
     pub fn push<B: BaubleError>(&mut self, error: B) {
         self.0.push(Box::new(error))
     }
@@ -159,6 +190,7 @@ impl BaubleErrors {
         }
     }
 
+    /// Will print all errors to stderr.
     pub fn print_errors(&self, ctx: &BaubleContext) {
         self.for_reports(
             |report| {
@@ -168,6 +200,7 @@ impl BaubleErrors {
         );
     }
 
+    /// Will write all errors to `w`.
     pub fn write_errors<W>(&self, ctx: &BaubleContext, w: &mut W)
     where
         W: std::io::Write,
@@ -198,6 +231,7 @@ impl<B: BaubleError> From<Vec<B>> for BaubleErrors {
     }
 }
 
+/// Will print the errors of `res` in case of an error, otherwise, return the ok value of `res` of type `T`.
 pub fn print_errors<T>(res: Result<T, impl Into<BaubleErrors>>, ctx: &BaubleContext) -> Option<T> {
     res.map_err(|errors| {
         let errors: BaubleErrors = errors.into();

--- a/bauble/src/error.rs
+++ b/bauble/src/error.rs
@@ -35,7 +35,6 @@ impl CustomError {
     }
 
     /// Highlights a span of code with an accompanying diagnostic message with a diagnostic relevance of `level`.
-    #[allow(missing_docs)]
     pub fn with_label(mut self, s: Spanned<impl Into<Cow<'static, str>>>, level: Level) -> Self {
         self.labels.push((s.map(|s| s.into()), level));
         self
@@ -44,7 +43,6 @@ impl CustomError {
     /// Highlights a span of code with an accompanying message.
     ///
     /// Shorthand for [`with_label`](Self::with_label) with an error level.
-    #[allow(missing_docs)]
     pub fn with_err_label(self, s: Spanned<impl Into<Cow<'static, str>>>) -> Self {
         self.with_label(s, Level::Error)
     }

--- a/bauble/src/lib.rs
+++ b/bauble/src/lib.rs
@@ -21,6 +21,8 @@
 //!
 //! Here is a following example of using `#[derive(Bauble)]` to create a Bauble parsable type.
 //! ```
+//! # use bauble::Bauble;
+//!
 //! #[derive(Bauble)]
 //! struct TypeInBauble {
 //!    a_number: u32,

--- a/bauble/src/lib.rs
+++ b/bauble/src/lib.rs
@@ -1,4 +1,38 @@
+//! Bauble is Rust-inspired human-readable text format for representing various Rust-like data, such as enums or structs.
+//!
+//! Data represented by Bauble can be parsed and stored in memory in the form of a corresponding type on Rust which implements
+//! the [`Bauble`] trait. In this way, Bauble is a format very useful for specifying information processed to Rust in a way
+//! that remains very consistent to the actual Rust code itself that makes use of the information.
+//!
+//! The code making use of Bauble has to construct a [`BaubleContext`] in order to provide the parsing step enough information
+//! for recognizing the different types inside of the Bauble source. Once a context has been created, that context can then be
+//! used for parsing various Bauble source files and extract the newly parsed data back as typed values that can be used to
+//! update the state of the program.
+//!
+//! # BaubleContext
+//!
+//! [`BaubleContext`] is used to register various Bauble source files to parse information from, as well as maintaining a type
+//! registry where every known type to Bauble is provided. All interactions with Bauble require a context.
+//!
+//! # Deriving Bauble
+//!
+//! In order to represent a type inside of Bauble, you must implement the `Bauble` trait for that type. To make this easier,
+//! Bauble has a custom derive macro `#[derive(Bauble)]`.
+//!
+//! Here is a following example of using `#[derive(Bauble)]` to create a Bauble parsable type.
+//! ```
+//! #[derive(Bauble)]
+//! struct TypeInBauble {
+//!    a_number: u32,
+//!    a_string: String,
+//!    a_bool: bool,
+//! }
+//! ```
+//!
+//! More information on the [`Bauble`] derive macro exists in its documentation.
+
 #![feature(iterator_try_collect, let_chains, ptr_metadata)]
+#![warn(missing_docs)]
 
 mod context;
 mod error;
@@ -47,6 +81,8 @@ fn parse(file_id: FileId, ctx: &BaubleContext) -> Result<ParseValues, BaubleErro
     })
 }
 
+// TODO(@docs)
+#[allow(missing_docs)]
 #[macro_export]
 macro_rules! bauble_test {
     ([$($ty:ty),* $(,)?] $source:literal [$($expr:expr),* $(,)?]) => {

--- a/bauble/src/traits.rs
+++ b/bauble/src/traits.rs
@@ -55,7 +55,7 @@ struct InnerToRustError {
     kind: ToRustErrorKind,
 }
 
-/// An error that occures during Bauble parsing, represented as a Rust enum.
+/// An error that occures during Bauble parsinoccurs during conversion from bauble to rust, represented as a Rust enum.
 #[allow(missing_docs)]
 #[derive(Debug, Clone, PartialEq)]
 pub enum ToRustErrorKind {

--- a/bauble/src/traits.rs
+++ b/bauble/src/traits.rs
@@ -55,7 +55,7 @@ struct InnerToRustError {
     kind: ToRustErrorKind,
 }
 
-/// An error that occures during Bauble parsinoccurs during conversion from bauble to rust, represented as a Rust enum.
+/// An error that occures during conversion from bauble to rust, represented as a Rust enum.
 #[allow(missing_docs)]
 #[derive(Debug, Clone, PartialEq)]
 pub enum ToRustErrorKind {

--- a/bauble/src/traits.rs
+++ b/bauble/src/traits.rs
@@ -10,6 +10,8 @@ use crate::{
     value::{Ident, PrimitiveValue},
 };
 
+/// Represents the different kinds of variants on an enum, where `Path` is a unit variant.
+#[allow(missing_docs)]
 #[derive(Clone, Debug, PartialEq)]
 pub enum VariantKind {
     Struct,
@@ -53,6 +55,8 @@ struct InnerToRustError {
     kind: ToRustErrorKind,
 }
 
+/// An error that occures during Bauble parsing, represented as a Rust enum.
+#[allow(missing_docs)]
 #[derive(Debug, Clone, PartialEq)]
 pub enum ToRustErrorKind {
     MissingField {
@@ -231,7 +235,10 @@ impl BaubleError for ToRustError {
 }
 
 // TODO Maybe `unsafe trait`?
+/// Used by bauble to abstract allocating various types.
 pub trait BaubleAllocator<'a> {
+    // TODO(@docs)
+    #[allow(missing_docs)]
     type Out<T>
     where
         Self: 'a;
@@ -244,6 +251,7 @@ pub trait BaubleAllocator<'a> {
     unsafe fn validate<T>(&self, value: Self::Out<T>) -> Result<T, ToRustError>;
 }
 
+/// The standard Rust allocator when used by Bauble.
 pub struct DefaultAllocator;
 
 impl BaubleAllocator<'_> for DefaultAllocator {
@@ -258,6 +266,7 @@ impl BaubleAllocator<'_> for DefaultAllocator {
     }
 }
 
+/// The trait used by types usable by Bauble. Any type that can be parsed by bauble should implement this trait.
 pub trait Bauble<'a, A: BaubleAllocator<'a> = DefaultAllocator>: Sized + 'static {
     /// # DON'T CALL THIS, call `TypeRegistry::get_or_register_type` instead.
     ///
@@ -267,6 +276,7 @@ pub trait Bauble<'a, A: BaubleAllocator<'a> = DefaultAllocator>: Sized + 'static
     /// Construct this type from a bauble value. This function doesn't do any type checking.
     fn from_bauble(val: Val, allocator: &A) -> Result<A::Out<Self>, ToRustError>;
 
+    #[allow(missing_docs)]
     fn error(span: crate::Span, error: impl Into<ToRustErrorKind>) -> ToRustError {
         ToRustError(Box::new(InnerToRustError {
             in_type: std::any::TypeId::of::<Self>(),

--- a/bauble/src/types.rs
+++ b/bauble/src/types.rs
@@ -1,4 +1,4 @@
-//! Bauble is a types format. This means that Bauble will be able to extract type information from the
+//! Bauble is a typed format. This means that Bauble will be able to extract type information from the
 //! [`BaubleContext`](crate::BaubleContext) and the parsed source files.
 //!
 //! The typed nature of Bauble brings many benefits such as improved error messages, allowing custom values,
@@ -117,7 +117,7 @@ pub enum VariantKind {
     Explicit(Fields),
 }
 
-/// A variant usable by an enum in Bauble.
+/// A variant usable by an enum in Bauble used for [`TypeRegistry::build_enum`].
 pub struct Variant {
     /// The identifier of the variant.
     pub ident: TypePathElem,
@@ -185,7 +185,7 @@ impl Variant {
     }
 }
 
-/// An error that occured within the Bauble context's type-system.
+/// An error that occured within the Bauble context's type-system during [`TypeRegister::validate`].
 #[allow(missing_docs)]
 #[derive(Debug)]
 pub enum TypeSystemError<'a> {

--- a/bauble/src/types/path.rs
+++ b/bauble/src/types/path.rs
@@ -65,6 +65,7 @@ impl<S: AsRef<str>> TryFrom<TypePath<S>> for TypePathElem<S> {
     }
 }
 
+#[allow(missing_docs)]
 impl<S: AsRef<str>> TypePathElem<S> {
     pub fn new(s: S) -> Result<Self> {
         let l = path_len(s.as_ref())?;
@@ -134,6 +135,8 @@ impl<S: AsRef<str>> std::fmt::Display for TypePath<S> {
     }
 }
 
+/// An error when forming paths.
+#[allow(missing_docs)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PathError {
     EmptyElem(usize),
@@ -143,6 +146,7 @@ pub enum PathError {
     ZeroElements,
 }
 
+/// A result type with an implicit `PathError`.
 pub type Result<T> = std::result::Result<T, PathError>;
 
 /// Iterates through a path, counting elements.
@@ -212,6 +216,7 @@ fn path_len(path: &str) -> Result<usize> {
 }
 
 impl TypePath {
+    /// Insert `other` at the start of `self`.
     pub fn push_start(&mut self, other: TypePath<impl AsRef<str>>) {
         if self.is_empty() {
             self.0.push_str(other.as_str());
@@ -221,6 +226,7 @@ impl TypePath {
         }
     }
 
+    /// Insert `other` at the end of `self`.
     pub fn push(&mut self, other: TypePath<impl AsRef<str>>) {
         if self.is_empty() {
             self.0.push_str(other.as_str());
@@ -230,6 +236,9 @@ impl TypePath {
         }
     }
 
+    /// Insert `other` at the end of `self`.
+    ///
+    /// This fails if `other` is not a valid path.
     pub fn push_str(&mut self, other: &str) -> Result<()> {
         self.push(TypePath::new(other)?);
         Ok(())
@@ -243,6 +252,7 @@ impl<S: AsRef<str>> AsRef<str> for TypePath<S> {
 }
 
 impl<S: AsRef<str>> TypePath<S> {
+    #[allow(missing_docs)]
     pub fn empty() -> Self
     where
         S: From<&'static str>,
@@ -250,44 +260,57 @@ impl<S: AsRef<str>> TypePath<S> {
         Self("".into())
     }
 
+    #[allow(missing_docs)]
     pub fn new(s: S) -> Result<Self> {
         path_len(s.as_ref())?;
 
         Ok(Self(s))
     }
 
+    #[allow(missing_docs)]
     pub fn try_into_elem(self) -> Result<TypePathElem<S>> {
         TypePathElem::try_from(self)
     }
 
+    #[allow(missing_docs)]
     pub fn into_inner(self) -> S {
         self.0
     }
 
+    #[allow(missing_docs)]
     pub fn as_str(&self) -> &str {
         self.0.as_ref()
     }
 
+    #[allow(missing_docs)]
     pub fn borrow(&self) -> TypePath<&str> {
         TypePath(self.as_str())
     }
 
+    /// The amount of segments in a path.
     pub fn len(&self) -> usize {
         path_len(self.as_str()).expect("Invariant")
     }
 
+    /// If the path is empty.
     pub fn is_empty(&self) -> bool {
         self.as_str().is_empty()
     }
 
+    /// The amount of bytes inside of the path.
     pub fn byte_len(&self) -> usize {
         self.as_str().len()
     }
 
+    #[allow(missing_docs)]
     pub fn to_owned(&self) -> TypePath {
         TypePath(self.as_str().to_string())
     }
 
+    /// Appends `other` to the end of `self`.
+    /// If `self` is empty, return `other`.
+    /// If `other` is empty, return `self`.
+    /// If both are empty, return an empty path.
     pub fn join<T: AsRef<str>>(&self, other: &TypePath<T>) -> TypePath {
         match (self.is_empty(), other.is_empty()) {
             (true, true) => TypePath::empty(),
@@ -297,20 +320,24 @@ impl<S: AsRef<str>> TypePath<S> {
         }
     }
 
+    /// Split the start segment with the remaining segments.
     pub fn get_start(&self) -> Option<(TypePathElem<&str>, TypePath<&str>)> {
         self.borrow().split_start()
     }
 
+    /// Split the end segment with the remaining segments.
     pub fn get_end(&self) -> Option<(TypePath<&str>, TypePathElem<&str>)> {
         self.borrow().split_end()
     }
 
+    /// Create an iterator for iterating the segments of `self`.
     pub fn iter(&self) -> PathIter {
         PathIter {
             path: self.borrow(),
         }
     }
 
+    /// Check if `self` ends with the path `other`.
     pub fn ends_with(&self, other: TypePath<&str>) -> bool {
         self.as_str().ends_with(other.as_str())
             && (self.byte_len() == other.byte_len()
@@ -319,6 +346,7 @@ impl<S: AsRef<str>> TypePath<S> {
                     .is_some_and(|i| &self.as_str()[i..i + PATH_SEPERATOR.len()] == PATH_SEPERATOR))
     }
 
+    /// Check if `self` start with the path `other`.
     pub fn starts_with(&self, other: TypePath<&str>) -> bool {
         self.as_str().starts_with(other.as_str())
             && (self.byte_len() == other.byte_len()
@@ -328,6 +356,8 @@ impl<S: AsRef<str>> TypePath<S> {
                     == Some(PATH_SEPERATOR))
     }
 
+    // TODO(@docs)
+    #[allow(missing_docs)]
     pub fn is_writable(&self) -> bool {
         !self.is_empty()
             && self.iter().all(|part| {
@@ -476,6 +506,7 @@ impl<'a> TypePath<&'a str> {
     }
 }
 
+/// An iterator of segments in a path.
 pub struct PathIter<'a> {
     path: TypePath<&'a str>,
 }

--- a/bauble/src/value/display.rs
+++ b/bauble/src/value/display.rs
@@ -1,3 +1,8 @@
+//! Provides helper functions for displaying Bauble values.
+
+// NOTE(@docs) the display API is self-explanatory.
+#![allow(missing_docs)]
+
 use std::collections::HashMap;
 
 use crate::{

--- a/bauble/src/value/error.rs
+++ b/bauble/src/value/error.rs
@@ -25,6 +25,8 @@ impl From<crate::path::PathError> for ConversionError {
     }
 }
 
+/// An error type for conversions that happen inside of Bauble.
+#[allow(missing_docs)]
 #[derive(Clone, Debug)]
 pub enum ConversionError {
     UnregisteredAsset,

--- a/bauble/src/value/mod.rs
+++ b/bauble/src/value/mod.rs
@@ -28,6 +28,8 @@ use error::Result;
 pub use error::{ConversionError, RefError, RefKind};
 pub(crate) use symbols::Symbols;
 
+// TODO(@docs)
+#[allow(missing_docs)]
 pub trait ValueTrait: Clone + std::fmt::Debug {
     type Inner: ValueContainer;
     type Ref;
@@ -43,13 +45,18 @@ pub trait ValueTrait: Clone + std::fmt::Debug {
     fn to_any(&self) -> AnyVal;
 }
 
+/// A helper trait for extracting the spans out of a Bauble value.
 pub trait SpannedValue: ValueTrait {
+    /// The span of the type of the value.
     fn type_span(&self) -> crate::Span;
 
+    /// The span of the parsed Bauble value.
     fn value_span(&self) -> crate::Span;
 
+    /// The span of the attributes to the Bauble value.
     fn attributes_span(&self) -> crate::Span;
 
+    #[allow(missing_docs)]
     fn span(&self) -> crate::Span {
         let attributes_span = self.attributes_span();
         let value_span = self.value_span();
@@ -61,6 +68,8 @@ pub trait SpannedValue: ValueTrait {
     }
 }
 
+// TODO(@docs)
+#[allow(missing_docs)]
 pub trait ValueContainer: Clone + std::fmt::Debug {
     type ContainerField: Hash + Eq + std::borrow::Borrow<str>;
 
@@ -138,6 +147,7 @@ impl ValueContainer for AnyVal<'_> {
     }
 }
 
+/// A map of Bauble attributes.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Attributes<V: ValueContainer = Val>(IndexMap<V::ContainerField, V>);
 
@@ -154,34 +164,42 @@ impl<V: ValueContainer> Default for Attributes<V> {
 }
 
 impl<V: ValueContainer> Attributes<V> {
+    #[allow(missing_docs)]
     pub fn len(&self) -> usize {
         self.0.len()
     }
 
+    #[allow(missing_docs)]
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 
+    /// Get the key and value of the attribute `s`.
     pub fn get(&self, s: &str) -> Option<(&V::ContainerField, &V)> {
         self.0.get_key_value(s)
     }
 
+    /// Iterate the values of all attributes.
     pub fn values(&self) -> impl ExactSizeIterator<Item = &V> {
         self.0.values()
     }
 
+    /// Iterate the key and value of all attributes and their fields.
     pub fn iter(&self) -> impl ExactSizeIterator<Item = (&V::ContainerField, &V)> {
         self.0.iter()
     }
 
+    /// Get the first attribute key and value.
     pub fn first(&self) -> Option<(&V::ContainerField, &V)> {
         self.0.first()
     }
 
+    /// Inserts an attribute `ident` with a value `v`.
     pub fn insert(&mut self, ident: V::ContainerField, v: V) {
         self.0.insert(ident, v);
     }
 
+    /// Remove and return the value of the attribute `ident` if such an attribute exists.
     pub fn take(&mut self, ident: &str) -> Option<V> {
         self.0.swap_remove(ident)
     }
@@ -208,10 +226,13 @@ impl<'a, T: ValueContainer> IntoIterator for &'a Attributes<T> {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-/// A value with attributes
+/// A [`Value`] with type information and attributes.
 pub struct Val {
+    /// The type of the parsed Bauble value.
     pub ty: Spanned<TypeId>,
+    /// The parsed Bauble value.
     pub value: Spanned<Value>,
+    /// Attributes associated with the parsed Bauble value.
     pub attributes: Spanned<Attributes>,
 }
 
@@ -256,6 +277,7 @@ impl SpannedValue for Val {
 }
 
 impl Val {
+    /// Return a version of `self` without span.
     pub fn into_unspanned(self) -> UnspannedVal {
         UnspannedVal {
             ty: *self.ty,
@@ -303,10 +325,14 @@ impl Val {
     }
 }
 
+/// A [`Val`] without span information.
 #[derive(Clone, Debug, PartialEq)]
 pub struct UnspannedVal {
+    /// The type of the parsed Bauble value.
     pub ty: TypeId,
+    /// The parsed Bauble value.
     pub value: Value<UnspannedVal>,
+    /// Attributes associated with the parsed Bauble value.
     pub attributes: Attributes<UnspannedVal>,
 }
 
@@ -350,11 +376,13 @@ impl UnspannedVal {
         }
     }
 
+    #[allow(missing_docs)]
     pub fn with_type(mut self, ty: TypeId) -> Self {
         self.ty = ty;
         self
     }
 
+    #[allow(missing_docs)]
     pub fn with_attribute(mut self, ty: TypeId) -> Self {
         self.ty = ty;
         self
@@ -434,14 +462,18 @@ pub type Fields<Inner = Val, Field = Ident> = IndexMap<Field, Inner>;
 
 pub type Sequence<Inner = Val> = Vec<Inner>;
 
+/// The kind of a field inside of Bauble.
+#[allow(missing_docs)]
 #[derive(Clone, Debug, PartialEq)]
 pub enum FieldsKind<Inner = Val, Field: Hash + Eq = Ident> {
+    // TODO(@docs)
     Unit,
     Unnamed(Sequence<Inner>),
     Named(Fields<Inner, Field>),
 }
 
 impl FieldsKind {
+    #[allow(missing_docs)]
     pub fn variant_kind(&self) -> VariantKind {
         match self {
             FieldsKind::Unit => VariantKind::Path,
@@ -451,6 +483,8 @@ impl FieldsKind {
     }
 }
 
+/// A value of a primitive type inside of Bauble.
+#[allow(missing_docs)]
 #[derive(Clone, Debug, PartialEq)]
 pub enum PrimitiveValue {
     Num(Decimal),
@@ -461,6 +495,11 @@ pub enum PrimitiveValue {
     Raw(String),
 }
 
+/// A parsed but untyped value from Bauble.
+///
+/// This is the fundemtnal building block of interpreteting Bauble.
+/// For a typed version with attributes, see [`Val`].
+#[allow(missing_docs)]
 #[derive(Clone, Debug, PartialEq)]
 pub enum Value<V: ValueTrait = Val> {
     // Fully resolved path.
@@ -483,6 +522,7 @@ pub enum Value<V: ValueTrait = Val> {
 }
 
 impl<T: ValueTrait> Value<T> {
+    /// If the value can be described by a primitive type.
     pub fn primitive_type(&self) -> Option<types::Primitive> {
         match self {
             Self::Primitive(p) => Some(match p {
@@ -498,6 +538,8 @@ impl<T: ValueTrait> Value<T> {
     }
 }
 
+/// Represents a value tied to a specific path.
+#[allow(missing_docs)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Object<Inner = Val> {
     pub object_path: TypePath,
@@ -505,6 +547,7 @@ pub struct Object<Inner = Val> {
 }
 
 impl Object<Val> {
+    #[allow(missing_docs)]
     pub fn into_unspanned(self) -> Object<UnspannedVal> {
         Object {
             object_path: self.object_path,


### PR DESCRIPTION
This PR adds documentation for various public API, adds a lint for missing documentation, and fixed some minor issue along the way.

Some documentation that should be added is still lacking and is marked with a `TODO(@docs)`.