### PR TITLE
The ability to state explicit value type

### DIFF
--- a/bauble/src/types.rs
+++ b/bauble/src/types.rs
@@ -236,6 +236,15 @@ impl Display for TypeSystemError<'_> {
 }
 
 impl TypeRegistry {
+    /// This is not performant and should not be exposed API, it is used for tests.
+    #[doc(hidden)]
+    pub fn find_rust_type(&self, ty: TypeId) -> Option<std::any::TypeId> {
+        self.type_from_rust
+            .iter()
+            .find(|(_, t)| **t == ty)
+            .map(|(t, _)| *t)
+    }
+
     pub(crate) fn new() -> Self {
         let mut this = Self {
             types: Default::default(),

--- a/bauble/src/types.rs
+++ b/bauble/src/types.rs
@@ -900,7 +900,13 @@ impl TypeRegistry {
                     .map(|v| crate::Value::Enum(variant.to_owned(), Box::new(v)))
             })?,
             TypeKind::Or(_) => crate::Value::Or(Vec::new()),
-            TypeKind::Ref(_) => return None,
+            TypeKind::Ref(inner) => {
+                if self.instantiate(*inner).is_some() {
+                    crate::Value::Primitive(crate::PrimitiveValue::Default)
+                } else {
+                    return None;
+                }
+            }
             TypeKind::Primitive(primitive) => crate::Value::Primitive(match primitive {
                 Primitive::Any => crate::PrimitiveValue::Unit,
                 Primitive::Num => crate::PrimitiveValue::Num(rust_decimal::Decimal::ZERO),

--- a/bauble/src/types.rs
+++ b/bauble/src/types.rs
@@ -60,7 +60,9 @@ impl From<GenericTypeId> for TypeId {
     }
 }
 
-// TODO(@docs)
+/// A [`GenericTypeId`] represents a generic type registed by a Bauble [`TypeRegistry`].
+///
+/// We maintain the invariant that the type is kind `TypeKind::Generic`
 #[allow(missing_docs)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct GenericTypeId(TypeId);
@@ -131,8 +133,7 @@ pub struct Variant {
     pub attributes: NamedFields,
     /// Additional validation to perform during parsing.
     pub extra_validation: Option<ValidationFunction>,
-    #[allow(missing_docs)]
-    // TODO(@docs)
+    /// Extra data attached by the user to the variant.
     pub extra: Extra,
     /// The default value to be assigned to this if there's a `default` value.
     pub default: Option<UnspannedVal>,
@@ -286,13 +287,12 @@ impl TypeRegistry {
         this
     }
 
-    /// If a type implements the required top-level type.
-    pub fn impls_top_level_type(&self, id: TypeId) -> bool {
+    /// If a type implements the required top-level trait.
+    pub fn impls_top_level_trait(&self, id: TypeId) -> bool {
         self.key_trait(self.top_level_trait_dependency).contains(id)
     }
 
-    // TODO(@docs)
-    #[allow(missing_docs)]
+    /// The trait that's expected for all top-level bauble assets to have.
     pub fn top_level_trait(&self) -> TraitId {
         self.top_level_trait_dependency
     }
@@ -700,8 +700,7 @@ impl TypeRegistry {
         }
     }
 
-    // TODO(@docs)
-    #[allow(missing_docs)]
+    /// Sets the trait all top-level assets are expected to have. By default this is the any trait.
     pub fn set_top_level_trait_dependency(&mut self, tr: TraitId) {
         self.top_level_trait_dependency = tr;
     }
@@ -717,14 +716,18 @@ impl TypeRegistry {
         tr.insert(ty);
     }
 
+    /// Retrieves a type, panicing if it doesn't exist.
+    ///
     /// # Panics
     /// Can panic if `TypeId` hasn't been constructed using this `TypeRegistry`.
     pub fn key_type(&self, id: impl Into<TypeId>) -> &Type {
         self.types.get(id.into().0).expect("unknown type id")
     }
 
-    // TODO(@docs)
-    #[allow(missing_docs)]
+    /// Retrieves a trait, panicing if it doesn't exist.
+    ///
+    /// # Panics
+    /// Can panic if `TraitId` hasn't been constructed using this `TypeRegistry`.
     pub fn key_trait(&self, id: TraitId) -> &TypeSet {
         match &self.key_type(id).kind {
             TypeKind::Trait(type_set) => type_set,
@@ -732,8 +735,10 @@ impl TypeRegistry {
         }
     }
 
-    // TODO(@docs)
-    #[allow(missing_docs)]
+    /// Retrieves a generic type, panicing if it doesn't exist.
+    ///
+    /// # Panics
+    /// Can panic if `GenericTypeId` hasn't been constructed using this `TypeRegistry`.
     pub fn key_generic(&self, id: GenericTypeId) -> &TypeSet {
         match &self.key_type(id).kind {
             TypeKind::Generic(type_set) => type_set,
@@ -751,8 +756,7 @@ impl TypeRegistry {
         self.type_id::<T, A>().map(|id| self.key_type(id))
     }
 
-    // TODO(@docs)
-    #[allow(missing_docs)]
+    /// Get a trait using the generic `dyn Trait`.
     pub fn get_trait<T: ?Sized + BaubleTrait>(&self) -> Option<&Type> {
         self.trait_id::<T>().map(|id| self.key_type(id))
     }
@@ -775,8 +779,9 @@ impl TypeRegistry {
         }
     }
 
-    // TODO(@docs)
-    #[allow(missing_docs)]
+    /// Gets the writeable path of a certain path.
+    ///
+    /// If this type is generic and its path isn't writable this will return the generic types path.
     pub fn get_writable_path(&self, ty: TypeId) -> Option<TypePath<&str>> {
         let p = self.key_type(ty).meta.path.borrow();
 
@@ -953,8 +958,7 @@ pub struct TypeMeta {
     pub attributes: NamedFields,
     /// If this type has any extra invariants that need to be checked.
     pub extra_validation: Option<ValidationFunction>,
-    // TODO(@docs)
-    #[allow(missing_docs)]
+    /// Extra data attached by the user to the type.
     pub extra: Extra,
 }
 
@@ -963,7 +967,7 @@ pub struct TypeMeta {
 #[derive(Debug, Clone)]
 pub struct FieldType {
     pub id: TypeId,
-    // TODO(@docs)
+    /// Extra data attached by the user to the field.
     pub extra: Extra,
     pub default: Option<UnspannedVal>,
 }
@@ -993,8 +997,8 @@ pub struct UnnamedFields {
     pub required: Vec<FieldType>,
     /// Optional fields, such as those specified by attributes with default values.
     pub optional: Vec<FieldType>,
-    // TODO(@docs)
-    #[allow(missing_docs)]
+    /// If this is some, it allows any amount of that field type following the last
+    /// defined required/optional field.
     pub allow_additional: Option<FieldType>,
 }
 
@@ -1028,8 +1032,7 @@ impl UnnamedFields {
         self
     }
 
-    // TODO(@docs)
-    #[allow(missing_docs)]
+    /// An `UnnamedFields` to allow any amount of fields of any type.
     pub fn any() -> Self {
         Self {
             allow_additional: Some(FieldType::from(TypeRegistry::any_type())),
@@ -1044,8 +1047,8 @@ pub struct NamedFields {
     pub required: IndexMap<String, FieldType>,
     /// Optional fields, such as those specified by attributes with default values.
     pub optional: IndexMap<String, FieldType>,
-    // TODO(@docs)
-    #[allow(missing_docs)]
+    /// If this is some, it allows a field of field names that aren't defined in `required`
+    /// or `òptional` as the specified type.
     pub allow_additional: Option<FieldType>,
 }
 

--- a/bauble/src/types.rs
+++ b/bauble/src/types.rs
@@ -716,7 +716,7 @@ impl TypeRegistry {
         tr.insert(ty);
     }
 
-    /// Retrieves a type, panicing if it doesn't exist.
+    /// Retrieves a type, panicking if it doesn't exist.
     ///
     /// # Panics
     /// Can panic if `TypeId` hasn't been constructed using this `TypeRegistry`.
@@ -724,7 +724,7 @@ impl TypeRegistry {
         self.types.get(id.into().0).expect("unknown type id")
     }
 
-    /// Retrieves a trait, panicing if it doesn't exist.
+    /// Retrieves a trait, panicking if it doesn't exist.
     ///
     /// # Panics
     /// Can panic if `TraitId` hasn't been constructed using this `TypeRegistry`.
@@ -735,7 +735,7 @@ impl TypeRegistry {
         }
     }
 
-    /// Retrieves a generic type, panicing if it doesn't exist.
+    /// Retrieves a generic type, panicking if it doesn't exist.
     ///
     /// # Panics
     /// Can panic if `GenericTypeId` hasn't been constructed using this `TypeRegistry`.

--- a/bauble/src/types/path.rs
+++ b/bauble/src/types/path.rs
@@ -65,8 +65,8 @@ impl<S: AsRef<str>> TryFrom<TypePath<S>> for TypePathElem<S> {
     }
 }
 
-#[allow(missing_docs)]
 impl<S: AsRef<str>> TypePathElem<S> {
+    /// Creates a new path element, returns err if it's not one element.
     pub fn new(s: S) -> Result<Self> {
         let l = path_len(s.as_ref())?;
         match l {
@@ -76,24 +76,22 @@ impl<S: AsRef<str>> TypePathElem<S> {
         }
     }
 
-    pub fn is_sub_asset_of(&self, other: TypePathElem<&str>) -> bool {
-        self.as_str()
-            .strip_prefix(other.as_str())
-            .is_some_and(|s| s.starts_with(['#', '&']))
-    }
-
+    /// Convert this to an owned path element.
     pub fn to_owned(&self) -> TypePathElem<String> {
         TypePathElem(self.0.to_owned())
     }
 
+    /// Borrow this path element.
     pub fn borrow(&self) -> TypePathElem<&str> {
         TypePathElem(self.0.borrow())
     }
 
+    /// For path elements this is always false.
     pub fn is_empty(&self) -> bool {
         false
     }
 
+    /// For path elements this is always one.
     pub fn len(&self) -> usize {
         1
     }
@@ -166,13 +164,21 @@ impl<S: AsRef<str>> std::fmt::Display for TypePath<S> {
 }
 
 /// An error when forming paths.
-#[allow(missing_docs)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PathError {
+    /// There was an empty path element, for example `foo::::bar`.
     EmptyElem(usize),
+    /// A start delimiter, i.e `<`, `(`, `[`, is missing its end equivalent.
     MissingDelimiterEnd(usize),
+    /// An end delimiter, i.e `>`, `)`, `]`, is missing its start equivalent.
     MissingDelimiterStart(usize),
+    /// Too many path elements.
+    ///
+    /// `TypePathElem` only allows one element.
     TooManyElements,
+    /// Zero path elements.
+    ///
+    /// `TypePathElem` needs one element.
     ZeroElements,
 }
 
@@ -306,7 +312,9 @@ impl<S> TypePath<S> {
 }
 
 impl<S: AsRef<str>> TypePath<S> {
-    #[allow(missing_docs)]
+    /// Create an empty type path.
+    ///
+    /// This is equivalent to `TypePath::new_unchecked("".into())`.
     pub fn empty() -> Self
     where
         S: From<&'static str>,
@@ -314,24 +322,26 @@ impl<S: AsRef<str>> TypePath<S> {
         Self("".into())
     }
 
-    #[allow(missing_docs)]
+    /// Create a new `TypePath` with checks that it is valid.
     pub fn new(s: S) -> Result<Self> {
         path_len(s.as_ref())?;
 
         Ok(Self(s))
     }
 
-    #[allow(missing_docs)]
+    /// Tries to convert this type path into a type path element.
+    ///
+    /// Only succeeds if `self.len() == 1`.
     pub fn try_into_elem(self) -> Result<TypePathElem<S>> {
         TypePathElem::try_from(self)
     }
 
-    #[allow(missing_docs)]
+    /// Get the internal string slice of this type path.
     pub fn as_str(&self) -> &str {
         self.0.as_ref()
     }
 
-    #[allow(missing_docs)]
+    /// Borrows this path.
     pub fn borrow(&self) -> TypePath<&str> {
         TypePath(self.as_str())
     }
@@ -351,7 +361,7 @@ impl<S: AsRef<str>> TypePath<S> {
         self.as_str().len()
     }
 
-    #[allow(missing_docs)]
+    /// Convert this into an owned type path.
     pub fn to_owned(&self) -> TypePath {
         TypePath(self.as_str().to_string())
     }
@@ -405,8 +415,12 @@ impl<S: AsRef<str>> TypePath<S> {
                     == Some(PATH_SEPERATOR))
     }
 
-    // TODO(@docs)
-    #[allow(missing_docs)]
+    /// Returns true if this type path is something that is allowed to be
+    /// written in the bauble format.
+    ///
+    /// This means that:
+    /// - The path is non-empty.
+    /// - All the path segments are valid rust identifiers.
     pub fn is_writable(&self) -> bool {
         !self.is_empty()
             && self.iter().all(|part| {

--- a/bauble/src/types/path.rs
+++ b/bauble/src/types/path.rs
@@ -76,6 +76,12 @@ impl<S: AsRef<str>> TypePathElem<S> {
         }
     }
 
+    pub fn is_sub_asset_of(&self, other: TypePathElem<&str>) -> bool {
+        self.as_str()
+            .strip_prefix(other.as_str())
+            .is_some_and(|s| s.starts_with(['#', '&']))
+    }
+
     pub fn to_owned(&self) -> TypePathElem<String> {
         TypePathElem(self.0.to_owned())
     }

--- a/bauble/src/value/convert.rs
+++ b/bauble/src/value/convert.rs
@@ -948,10 +948,16 @@ where
                 }
                 // or we convert from a flat one.
                 (types::TypeKind::Transparent(ty), _) => {
+                    // If the cvalue type is this transparent type, project it to the represented value.
+                    let val_ty = if raw_val_type.is_some_and(|v| *v == *ty_id) {
+                        raw_val_type.map(|v| v.map(|_| *ty))
+                    } else {
+                        raw_val_type
+                    };
                     let val = extra_attributes.convert_inner_with(
                         value,
                         Spanned::new(attributes_span, &Default::default()),
-                        raw_val_type,
+                        val_ty,
                         meta.reborrow(),
                         *ty,
                     )?;

--- a/bauble/src/value/convert.rs
+++ b/bauble/src/value/convert.rs
@@ -948,7 +948,7 @@ where
                 }
                 // or we convert from a flat one.
                 (types::TypeKind::Transparent(ty), _) => {
-                    // If the cvalue type is this transparent type, project it to the represented value.
+                    // If the value type is this transparent type, project it to the represented value.
                     let val_ty = if raw_val_type.is_some_and(|v| *v == *ty_id) {
                         raw_val_type.map(|v| v.map(|_| *ty))
                     } else {

--- a/bauble/src/value/display.rs
+++ b/bauble/src/value/display.rs
@@ -457,10 +457,15 @@ impl IndentedDisplay<ValueDisplayCtx<'_, UnspannedVal>> for UnspannedVal {
         let mut w = w.with_type(path.as_str());
 
         if !w.is_typed()
-            && !matches!(
-                self.value,
-                Value::Struct(_) | Value::Enum(_, _) | Value::Or(_)
-            )
+            && !path.is_empty()
+            && match w.ctx().types.key_type(self.ty).kind {
+                TypeKind::Struct(_)
+                | TypeKind::Enum { .. }
+                | TypeKind::Or(_)
+                | TypeKind::EnumVariant { .. } => false,
+                TypeKind::Primitive(p) => w.ctx().types.primitive_type(p) == self.ty,
+                _ => true,
+            }
         {
             w.write("<");
             w.write_type();
@@ -506,10 +511,15 @@ impl IndentedDisplay<ValueDisplayCtx<'_, Val>> for Val {
         let mut w = w.with_type(path.as_str());
 
         if !w.is_typed()
-            && !matches!(
-                *self.value,
-                Value::Struct(_) | Value::Enum(_, _) | Value::Or(_)
-            )
+            && !path.is_empty()
+            && match w.ctx().types.key_type(*self.ty).kind {
+                TypeKind::Struct(_)
+                | TypeKind::Enum { .. }
+                | TypeKind::Or(_)
+                | TypeKind::EnumVariant { .. } => false,
+                TypeKind::Primitive(p) => w.ctx().types.primitive_type(p) == *self.ty,
+                _ => true,
+            }
         {
             w.write("<");
             w.write_type();

--- a/bauble/src/value/mod.rs
+++ b/bauble/src/value/mod.rs
@@ -1106,7 +1106,7 @@ fn create_object(
     value: Val,
     symbols: &Symbols,
 ) -> Result<Object> {
-    if symbols.ctx.type_registry().impls_top_level_type(*value.ty) {
+    if symbols.ctx.type_registry().impls_top_level_trait(*value.ty) {
         Ok(Object {
             object_path: path.join(&name),
             value,

--- a/bauble/src/value/mod.rs
+++ b/bauble/src/value/mod.rs
@@ -184,6 +184,10 @@ impl<V: ValueContainer> Attributes<V> {
         self.0.values()
     }
 
+    pub fn values_mut(&mut self) -> impl ExactSizeIterator<Item = &mut V> {
+        self.0.values_mut()
+    }
+
     /// Iterate the key and value of all attributes and their fields.
     pub fn iter(&self) -> impl ExactSizeIterator<Item = (&V::ContainerField, &V)> {
         self.0.iter()
@@ -207,6 +211,10 @@ impl<V: ValueContainer> Attributes<V> {
     /// Get the inner fields of an attribute.
     pub fn get_inner(&self) -> &Fields<V> {
         &self.0
+    }
+
+    pub fn get_inner_mut(&mut self) -> &mut Fields<V> {
+        &mut self.0
     }
 }
 


### PR DESCRIPTION
This adds the functionality to explicitly state the type with `<type::path>` in-front of a value.