### PR TITLE
Misc improvements

### DIFF
--- a/bauble/src/context.rs
+++ b/bauble/src/context.rs
@@ -173,6 +173,13 @@ impl BaubleContextBuilder {
             panic!("Type system error: {e}");
         }
         let mut root_node = CtxNode::new(TypePath::empty());
+        // Every default use is added as a child node of the root with a redirect reference that
+        // points to the full path.
+        //
+        // As children of the root they are directly referencable by the provided name in any file.
+        //
+        // If other references are available at the same name, they will be preferred over the
+        // redirect.
         for (id, path) in self.default_uses.0 {
             root_node.add_node(id.borrow()).reference.redirect = Some(path);
         }
@@ -609,7 +616,7 @@ impl BaubleContext {
             // Need a partial borrow here.
             let (path, _) = self.file(*file);
             let path = path.to_owned();
-            match crate::value::register_assets(path.borrow(), self, [], values) {
+            match crate::value::register_assets(path.borrow(), self, values) {
                 Ok(d) => {
                     delayed.extend(d);
                 }

--- a/bauble/src/context.rs
+++ b/bauble/src/context.rs
@@ -760,7 +760,7 @@ impl BaubleContext {
     }
 
     /// Get all the references starting from `path` which belong to `kind`, with an optional maximum depth of `max_depth`.
-    pub fn ref_kinds(
+    pub fn refs_of_kind(
         &self,
         path: TypePath<&str>,
         kind: crate::value::RefKind,

--- a/bauble/src/context.rs
+++ b/bauble/src/context.rs
@@ -12,13 +12,6 @@ pub type Source = ariadne::Source<String>;
 #[derive(Clone, Default)]
 struct DefaultUses(IndexMap<TypePathElem, TypePath>);
 
-#[derive(Default, Clone, Debug)]
-struct InnerReference {
-    ty: Option<TypeId>,
-    asset: Option<TypeId>,
-    redirect: Option<TypePath>,
-}
-
 /// A type containing multiple references generally derived from a path.
 #[derive(Default, Clone, Debug)]
 pub struct PathReference {
@@ -159,8 +152,6 @@ impl BaubleContextBuilder {
         self
     }
 
-    // TODO: documentation
-    #[allow(missing_docs)]
     /// # Panics
     ///
     /// Can panic if `T`'s `TypeKind` isn't a primitive.
@@ -201,9 +192,29 @@ impl BaubleContextBuilder {
     }
 }
 
+#[derive(Default, Clone, Debug)]
+struct InnerReference {
+    ty: Option<TypeId>,
+    asset: Option<TypeId>,
+    redirect: Option<TypePath>,
+}
+
+/// Represents a name in one or multiple of the type, asset, module, and default use namespaces.
+///
+/// If there is a module at this name, this holds a list of the `CtxNode`s in that module.
 #[derive(Clone, Debug)]
 struct CtxNode {
+    /// This name can potentially reference:
+    /// * A type
+    /// * An asset
+    /// * A default use (aka `InnerReference::redirect`) (TODO: actually look into this, I don't
+    ///   understand why these are only added to the root node so I don't actually know how they
+    ///   work)
+    /// * A module (not represented here but via the `Self::children` field).
     reference: InnerReference,
+    /// Full path to this node.
+    ///
+    /// This is the path to reach this node from the root.
     path: TypePath,
     /// `Some` when this node is the top level module of a file (currently inline modules don't
     /// exist but there is some allowance for them).
@@ -217,9 +228,9 @@ impl CtxNode {
     fn new(path: TypePath) -> Self {
         Self {
             path,
-            reference: Default::default(),
-            source: Default::default(),
-            children: Default::default(),
+            reference: InnerReference::default(),
+            source: None,
+            children: IndexMap::<_, _>::default(),
         }
     }
 

--- a/bauble/src/lib.rs
+++ b/bauble/src/lib.rs
@@ -48,17 +48,16 @@ pub mod types;
 pub use bauble_macros::Bauble;
 
 pub use context::{BaubleContext, BaubleContextBuilder, FileId, PathReference, Source};
-pub use error::{print_errors, BaubleError, BaubleErrors, CustomError, Level};
+pub use error::{BaubleError, BaubleErrors, CustomError, Level, print_errors};
 pub use spanned::{Span, SpanExt, Spanned};
 pub use traits::{
     Bauble, BaubleAllocator, DefaultAllocator, ToRustError, ToRustErrorKind, VariantKind,
 };
 pub use types::path;
 pub use value::{
-    compare_object_sets, display_formatted, AdditionalUnspannedObjects, Attributes,
-    CompareObjectsError, ConversionError, DisplayConfig, Fields, FieldsKind, IndentedDisplay, Map,
-    Object, PrimitiveValue, Sequence, SpannedValue, UnspannedVal, Val, Value, ValueContainer,
-    ValueTrait,
+    AdditionalUnspannedObjects, Attributes, CompareObjectsError, ConversionError, DisplayConfig,
+    Fields, FieldsKind, IndentedDisplay, Map, Object, PrimitiveValue, Sequence, SpannedValue,
+    UnspannedVal, Val, Value, ValueContainer, ValueTrait, compare_object_sets, display_formatted,
 };
 
 // re-exporting crates from other crates

--- a/bauble/src/lib.rs
+++ b/bauble/src/lib.rs
@@ -68,24 +68,6 @@ pub mod private {
     pub use indexmap::IndexMap;
 }
 
-use parse::ParseValues;
-
-fn parse(file_id: FileId, ctx: &BaubleContext) -> Result<ParseValues, BaubleErrors> {
-    use chumsky::Parser;
-
-    let parser = parse::parser();
-    let result = parser.parse(parse::ParserSource { file_id, ctx });
-
-    result.into_result().map_err(|errors| {
-        BaubleErrors::from(
-            errors
-                .into_iter()
-                .map(|e| e.into_owned())
-                .collect::<Vec<_>>(),
-        )
-    })
-}
-
 // TODO(@docs)
 #[allow(missing_docs)]
 #[macro_export]

--- a/bauble/src/lib.rs
+++ b/bauble/src/lib.rs
@@ -72,10 +72,10 @@ pub mod private {
 #[allow(missing_docs)]
 #[macro_export]
 macro_rules! bauble_test {
-    ( [$($ty:ty),* $(,)?] $source:literal [$($expr:expr),* $(,)?]) => {
-        $crate::bauble_test!(__TEST_CTX [$($ty),*] $source [$($expr),*])
+    ( [$($ty:ty),* $(,)?] $source:literal [$($test_value:expr),* $(,)?]) => {
+        $crate::bauble_test!(__TEST_CTX [$($ty),*] $source [$($test_value),*])
     };
-    ($ctx_static:ident [$($ty:ty),* $(,)?] $source:literal [$($expr:expr),* $(,)?]) => {
+    ($ctx_static:ident [$($ty:ty),* $(,)?] $source:literal [$($test_value:expr),* $(,)?]) => {
         static $ctx_static: std::sync::OnceLock<std::sync::RwLock<$crate::BaubleContext>> = std::sync::OnceLock::new();
         {
             let file_path = $crate::path::TypePath::new("test").unwrap();
@@ -91,14 +91,15 @@ macro_rules! bauble_test {
                 std::sync::RwLock::new(ctx)
             });
 
+            // Test initial parsing from source
             let (objects, errors) = ctx.write().unwrap().load_all();
 
             if !errors.is_empty() {
                 $crate::print_errors(Err::<(), _>(errors), &ctx.read().unwrap());
-
                 panic!("Error converting");
             }
 
+            // Test round-trip of objects through source format
             let re_source = $crate::display_formatted(objects.as_slice(), ctx.read().unwrap().type_registry(), &$crate::DisplayConfig {
                 ..$crate::DisplayConfig::default()
             });
@@ -107,29 +108,35 @@ macro_rules! bauble_test {
 
             if !errors.is_empty() {
                 $crate::print_errors(Err::<(), _>(errors), &ctx.read().unwrap());
-
-                println!("{re_source}");
-
+                eprintln!("{re_source}");
                 panic!("Error re-converting");
             }
 
+            assert_eq!(objects, re_objects);
+
+            // Test that original parsed objects and round-trip objects convert into typed values
+            // that match the provided test values.
             let compare_objects = |mut objects: Vec<$crate::Object>| {
                 let mut objects = objects.into_iter();
 
                 $(
                     let value = objects.next().expect("Not as many objects as test expr in bauble test?");
-                    let mut read_value = $expr;
-                    let test_value = ::std::mem::replace(&mut read_value, $crate::print_errors(Bauble::from_bauble(value.value, &::bauble::DefaultAllocator), &ctx.read().unwrap()).unwrap());
+                    // Infer type for `read_value` to be the same as `test_value`.
+                    let [test_value, read_value] = [
+                        $test_value,
+                        $crate::print_errors(
+                            $crate::Bauble::from_bauble(value.value, &$crate::DefaultAllocator),
+                            &ctx.read().unwrap()
+                        ).unwrap(),
+                    ];
 
-
-                    assert_eq!(
-                        read_value,
-                        test_value,
-                    );
+                    assert_eq!(read_value, test_value);
                 )*
-            };
 
-            assert_eq!(objects, re_objects);
+                if objects.next().is_some() {
+                    panic!("More objects in bauble test than test expr?");
+                }
+            };
 
             compare_objects(objects);
             compare_objects(re_objects);

--- a/bauble/src/parse/parser.rs
+++ b/bauble/src/parse/parser.rs
@@ -454,7 +454,7 @@ pub fn parser<'a>() -> impl Parser<'a, ParserSource<'a>, ParseValues, Extra<'a>>
                     '{',
                     '}',
                     [('[', ']'), ('(', ')')],
-                    |_| crate::parse::Fields::new(),
+                    |_| IndexMap::<Ident, ParseVal>::new(),
                 )));
 
             let reference = just('$').ignore_then(path).map(|path| {

--- a/bauble/src/parse/value.rs
+++ b/bauble/src/parse/value.rs
@@ -9,6 +9,7 @@ use indexmap::IndexMap;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum PathEnd {
+    // TODO: document how this syntax works?
     /// path::*::ident
     WithIdent(Ident),
     /// path::ident

--- a/bauble/src/parse/value.rs
+++ b/bauble/src/parse/value.rs
@@ -7,10 +7,6 @@ use crate::{
 };
 use indexmap::IndexMap;
 
-pub type Fields = IndexMap<Ident, ParseVal>;
-
-pub type Use = Spanned<PathTreeNode>;
-
 #[derive(Clone, Debug, PartialEq)]
 pub enum PathEnd {
     /// path::*::ident
@@ -77,7 +73,7 @@ impl fmt::Debug for Path {
 
 #[derive(Debug)]
 pub enum PathTreeEnd {
-    Group(Vec<Use>),
+    Group(Vec<Spanned<PathTreeNode>>),
     Everything,
     PathEnd(PathEnd),
 }
@@ -88,14 +84,11 @@ pub struct PathTreeNode {
     pub end: Spanned<PathTreeEnd>,
 }
 
-pub type Attributes = crate::value::Attributes<ParseVal>;
-pub type Value = crate::Value<ParseVal>;
-
 #[derive(Debug, Clone)]
 pub struct ParseVal {
     pub ty: Option<Path>,
-    pub attributes: Spanned<Attributes>,
-    pub value: Spanned<Value>,
+    pub attributes: Spanned<crate::Attributes<ParseVal>>,
+    pub value: Spanned<crate::Value<ParseVal>>,
 }
 
 impl ValueTrait for ParseVal {
@@ -149,7 +142,7 @@ pub struct Binding {
 
 #[derive(Debug)]
 pub struct ParseValues {
-    pub uses: Vec<Use>,
+    pub uses: Vec<Spanned<PathTreeNode>>,
     pub values: IndexMap<Ident, Binding>,
     pub copies: IndexMap<Ident, Binding>,
 }

--- a/bauble/src/spanned.rs
+++ b/bauble/src/spanned.rs
@@ -9,8 +9,9 @@ use std::{
 use crate::context::FileId;
 
 /// Represents a span in the parsed source of the Bauble context.
-/// This type correspond to the byte offset of the first character and the byte offset of the last character
-/// in a file.
+///
+/// This type corresponds to the byte offset in a file of the first character and the byte offset
+/// just past the last character.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Span {
     /// The offset to the first character covered by the span.

--- a/bauble/src/types.rs
+++ b/bauble/src/types.rs
@@ -18,7 +18,7 @@ pub mod path;
 use indexmap::IndexMap;
 use path::{TypePath, TypePathElem};
 
-use crate::{value::UnspannedVal, AdditionalUnspannedObjects, Bauble, BaubleAllocator};
+use crate::{AdditionalUnspannedObjects, Bauble, BaubleAllocator, value::UnspannedVal};
 
 #[allow(missing_docs)]
 pub type Extra = IndexMap<String, String>;
@@ -276,7 +276,7 @@ impl TypeRegistry {
 
         // The element at index 0 is always any trait
         let any_trait = this.get_or_register_trait::<dyn std::any::Any>();
-        this.types[any_trait.0 .0].kind = TypeKind::Trait(TypeSet(SealedTypeSet::All));
+        this.types[any_trait.0.0].kind = TypeKind::Trait(TypeSet(SealedTypeSet::All));
 
         // The element at index 1 is any trait.
         let any_id = this.get_or_register_type::<crate::Val, crate::DefaultAllocator>();
@@ -445,7 +445,7 @@ impl TypeRegistry {
 
     fn on_register_type(&mut self, id: TypeId, ty: &mut Type) {
         for tr in ty.meta.traits.iter() {
-            let TypeKind::Trait(types) = &mut self.types[tr.0 .0].kind else {
+            let TypeKind::Trait(types) = &mut self.types[tr.0.0].kind else {
                 panic!("Invariant")
             };
 
@@ -517,7 +517,7 @@ impl TypeRegistry {
         }
 
         if let Some(ty) = ty.meta.generic_base_type {
-            let TypeKind::Generic(types) = &mut self.types[ty.0 .0].kind else {
+            let TypeKind::Generic(types) = &mut self.types[ty.0.0].kind else {
                 panic!("`generic_base_type` pointing to a type that isn't `TypeKind::Generic`")
             };
 
@@ -756,7 +756,7 @@ impl TypeRegistry {
     pub fn add_trait_dependency(&mut self, ty: TypeId, tr: TraitId) {
         self.types[ty.0].meta.traits.push(tr);
 
-        let TypeKind::Trait(tr) = &mut self.types[tr.0 .0].kind else {
+        let TypeKind::Trait(tr) = &mut self.types[tr.0.0].kind else {
             unreachable!("Invariant");
         };
 

--- a/bauble/src/value/convert.rs
+++ b/bauble/src/value/convert.rs
@@ -1021,36 +1021,36 @@ where
                     if matches!(f, FieldsKind::Unit) {
                         if let Some(val_type) = raw_val_type {
                             match &types.key_type(val_type.value).kind {
-                            types::TypeKind::EnumVariant {
-                                variant,
-                                enum_type,
-                                fields,
-                            } => {
-                                debug_assert!(matches!(fields, types::Fields::Unit));
-                                debug_assert_eq!(*enum_type, *ty_id);
-                                debug_assert!(variants.variants.contains(variant));
+                                types::TypeKind::EnumVariant {
+                                    variant,
+                                    enum_type,
+                                    fields,
+                                } => {
+                                    debug_assert!(matches!(fields, types::Fields::Unit));
+                                    debug_assert_eq!(*enum_type, *ty_id);
+                                    debug_assert!(variants.variants.contains(variant));
 
-                                Value::Or(vec![variant.clone().spanned(span)])
+                                    Value::Or(vec![variant.clone().spanned(span)])
+                                }
+
+                                types::TypeKind::Generic(generic) => types
+                                    .iter_type_set(generic)
+                                    .next()
+                                    .map(|t| {
+                                        if let types::TypeKind::EnumVariant { variant, .. } =
+                                            &types.key_type(t).kind
+                                        {
+                                            Value::Or(vec![variant.clone().spanned(span)])
+                                        } else {
+                                            unreachable!(
+                                                "Our type checking should make sure this can't happen"
+                                            )
+                                        }
+                                    })
+                                    .expect("Our type checking should make sure this can't happen"),
+
+                                _ => Err(expected_err())?,
                             }
-
-                            types::TypeKind::Generic(generic) => types
-                                .iter_type_set(generic)
-                                .next()
-                                .map(|t| {
-                                    if let types::TypeKind::EnumVariant { variant, .. } =
-                                        &types.key_type(t).kind
-                                    {
-                                        Value::Or(vec![variant.clone().spanned(span)])
-                                    } else {
-                                        unreachable!(
-                                            "Our type checking should make sure this can't happen"
-                                        )
-                                    }
-                                })
-                                .expect("Our type checking should make sure this can't happen"),
-
-                            _ => Err(expected_err())?,
-                        }
                         } else {
                             Err(expected_err())?
                         }

--- a/bauble/src/value/convert.rs
+++ b/bauble/src/value/convert.rs
@@ -101,7 +101,7 @@ pub(super) fn value_type(value: &ParseVal, symbols: &Symbols) -> Result<Option<S
         return Ok(Some(symbols.resolve_type(ty)?.spanned(ty.span())));
     };
 
-    let ty = match &value.value.value {
+    let ty = match &*value.value {
         Value::Ref(path) => {
             // Don't resolve types of copy types.
             if let Some(ident) = path.as_ident()

--- a/bauble/src/value/display.rs
+++ b/bauble/src/value/display.rs
@@ -6,10 +6,10 @@
 use std::{borrow::Borrow, collections::HashMap};
 
 use crate::{
-    parse::{allowed_in_raw_literal, ParseVal, ParseValues, PathTreeEnd, PathTreeNode},
+    Spanned,
+    parse::{ParseVal, ParseValues, PathTreeEnd, PathTreeNode, allowed_in_raw_literal},
     path::TypePath,
     types::{TypeKind, TypeRegistry},
-    Spanned,
 };
 
 use super::{Attributes, FieldsKind, Object, UnspannedVal, Val, Value, ValueContainer, ValueTrait};

--- a/bauble/src/value/error.rs
+++ b/bauble/src/value/error.rs
@@ -572,7 +572,7 @@ impl BaubleError for Spanned<ConversionError> {
                 match &ref_err.path {
                     PathKind::Direct(path) => {
                         let options = ctx
-                            .ref_kinds(TypePath::empty(), ref_err.kind, None)
+                            .refs_of_kind(TypePath::empty(), ref_err.kind, None)
                             .map(|p| p.into_inner());
                         if path.len() == 1
                             && let Some(uses) = &ref_err.uses
@@ -604,7 +604,7 @@ impl BaubleError for Spanned<ConversionError> {
                     }
                     PathKind::Indirect(module, ident) => {
                         if let Some(suggestions) = get_suggestions(
-                            ctx.ref_kinds(module.borrow(), ref_err.kind, None)
+                            ctx.refs_of_kind(module.borrow(), ref_err.kind, None)
                                 .filter_map(|s| {
                                     s.split_end()
                                         .map(|(_, ident)| format!("{module}::*::{ident}"))
@@ -673,7 +673,7 @@ impl BaubleError for Spanned<ConversionError> {
             && ident.len() == 1
         {
             let suggestions = ctx
-                .ref_kinds(TypePath::empty(), ref_err.kind, None)
+                .refs_of_kind(TypePath::empty(), ref_err.kind, None)
                 .filter(|path| path.ends_with(ident.borrow()))
                 .map(|path| format!("`{path}`"))
                 .collect::<Vec<_>>();

--- a/bauble/src/value/mod.rs
+++ b/bauble/src/value/mod.rs
@@ -678,6 +678,8 @@ pub(crate) fn resolve_delayed(
         delayed.retain(|d| {
             if let Some(r) = match &d.reference.value {
                 PathKind::Direct(path) => ctx.get_ref(path.borrow()),
+                // TODO: what if indirect path becomes ambiguous due to later registered items that
+                // were delayed?
                 PathKind::Indirect(path, ident) => {
                     ctx.ref_with_ident(path.borrow(), ident.borrow())
                 }
@@ -722,6 +724,8 @@ pub(crate) fn resolve_delayed(
                             .spanned(scc[0].span),
                         )
                     } else {
+                        // TODO: Is this path possible? Wouldn't Ref have to refer to itself for
+                        // scc.len() == 1?
                         errors.push(
                             ConversionError::RefError(Box::new(RefError {
                                 // TODO: Could pass uses here for better suggestions.

--- a/bauble/src/value/mod.rs
+++ b/bauble/src/value/mod.rs
@@ -8,12 +8,12 @@ use rust_decimal::Decimal;
 use symbols::RefCopy;
 
 use crate::{
+    BaubleErrors, FileId, VariantKind,
     context::PathReference,
     parse::{ParseVal, ParseValues, Path, PathEnd},
     path::{TypePath, TypePathElem},
     spanned::{SpanExt, Spanned},
     types::{self, TypeId},
-    BaubleErrors, FileId, VariantKind,
 };
 
 mod convert;
@@ -23,8 +23,8 @@ mod symbols;
 
 pub use convert::AdditionalUnspannedObjects;
 pub(crate) use convert::AnyVal;
-use convert::{no_attr, value_type, AdditionalObjects, ConvertMeta, ConvertValue};
-pub use display::{display_formatted, DisplayConfig, IndentedDisplay};
+use convert::{AdditionalObjects, ConvertMeta, ConvertValue, no_attr, value_type};
+pub use display::{DisplayConfig, IndentedDisplay, display_formatted};
 use error::Result;
 pub use error::{ConversionError, RefError, RefKind};
 pub(crate) use symbols::Symbols;

--- a/bauble/src/value/mod.rs
+++ b/bauble/src/value/mod.rs
@@ -762,29 +762,20 @@ pub(crate) fn resolve_delayed(
 pub(crate) fn register_assets(
     path: TypePath<&str>,
     ctx: &mut crate::context::BaubleContext,
-    default_uses: impl IntoIterator<Item = (TypePathElem, PathReference)>,
     values: &ParseValues,
 ) -> std::result::Result<Vec<DelayedRegister>, Vec<Spanned<ConversionError>>> {
     let mut errors = Vec::new();
     let mut delayed = Vec::new();
 
-    // Add default uses to symbols
-    let default_uses = default_uses
-        .into_iter()
-        .map(|(key, val)| (key, RefCopy::Ref(val)))
-        .collect();
-    let mut symbols = Symbols {
-        ctx: &*ctx,
-        uses: default_uses,
-    };
+    let mut symbols = Symbols::new(ctx);
     // Add `uses` to local `Symbols` instance
-    for use_ in &values.uses {
-        if let Err(e) = symbols.add_use(use_) {
+    for use_path in &values.uses {
+        if let Err(e) = symbols.add_use(use_path) {
             errors.push(e);
         }
     }
 
-    // Move uses in/out of `Symbols` every loop so we have mutable access to `ctx` at certain
+    // Move `uses` in/out of `Symbols` every loop so we have mutable access to `ctx` at certain
     // points.
     let Symbols { mut uses, .. } = symbols;
 

--- a/bauble/src/value/symbols.rs
+++ b/bauble/src/value/symbols.rs
@@ -82,6 +82,7 @@ impl<'a> Symbols<'a> {
     }
 
     pub fn add(&mut self, symbols: Symbols) {
+        // TODO: what about conflicting entries?
         self.uses.extend(symbols.uses)
     }
 

--- a/bauble/src/value/symbols.rs
+++ b/bauble/src/value/symbols.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, collections::HashMap};
 use crate::{
     BaubleContext,
     context::PathReference,
-    parse::{Path, PathEnd, PathTreeEnd, Use},
+    parse::{Path, PathEnd, PathTreeEnd, PathTreeNode},
     path::{TypePath, TypePathElem},
     spanned::{SpanExt, Spanned},
     types::{self, TypeId},
@@ -75,7 +75,7 @@ impl<'a> Symbols<'a> {
         self.uses.extend(symbols.uses)
     }
 
-    pub fn add_use(&mut self, use_: &Use) -> Result<()> {
+    pub fn add_use(&mut self, use_path: &Spanned<PathTreeNode>) -> Result<()> {
         fn add_use_inner(
             this: &mut Symbols,
             leading: TypePath,
@@ -154,7 +154,7 @@ impl<'a> Symbols<'a> {
         }
 
         let mut leading = TypePath::empty();
-        for l in use_.leading.iter() {
+        for l in use_path.leading.iter() {
             leading.push_str(l).map_err(|e| e.spanned(l.span))?;
             if self.ctx.get_ref(leading.borrow()).is_none() {
                 return Err(ConversionError::RefError(Box::new(RefError {
@@ -166,7 +166,7 @@ impl<'a> Symbols<'a> {
                 .spanned(l.span));
             }
         }
-        add_use_inner(self, leading, &use_.end)
+        add_use_inner(self, leading, &use_path.end)
     }
 
     pub(super) fn try_resolve_copy<'b>(

--- a/bauble/src/value/symbols.rs
+++ b/bauble/src/value/symbols.rs
@@ -11,10 +11,14 @@ use crate::{
 
 use super::{ConversionError, CopyVal, PathKind, RefError, RefKind, Result};
 
+/// This either a reference to another value or a "copy" value which was copied into here.
 #[derive(Clone, Debug)]
 pub(super) enum RefCopy {
+    /// Unresolved copy value.
     Unresolved,
+    /// Resolved copy value.
     Resolved(CopyVal),
+    /// Reference to a type, asset, or module?
     Ref(PathReference),
 }
 
@@ -42,9 +46,15 @@ impl RefCopy {
     }
 }
 
+/// Representation of item names available in the current module.
+///
+/// There are multiple namespaces: types, assets (i.e. values defined in bauble), and modules.
+/// There are also copy values (TODO: which overlap all namespaces?).
 #[derive(Clone)]
 pub(crate) struct Symbols<'a> {
     pub(super) ctx: &'a BaubleContext,
+    // Map of identifiers to ref-copies (which can be unresolved-copy, resolved-copy, or reference)
+    // A resolved copy is either `CopyVal::Copy` or `CopyVal::Resolved(Val)`
     pub(super) uses: HashMap<TypePathElem, RefCopy>,
 }
 

--- a/bauble/tests/integration.rs
+++ b/bauble/tests/integration.rs
@@ -1,0 +1,123 @@
+#![allow(clippy::type_complexity)]
+use bauble::Bauble;
+use bauble::BaubleContext;
+use bauble::Object;
+use bauble::path::TypePath;
+
+#[derive(Bauble, PartialEq, Debug)]
+struct Test {
+    x: i32,
+    y: u32,
+}
+
+fn expected_value_fn<T: for<'a> Bauble<'a> + PartialEq + std::fmt::Debug>(
+    expected_value: T,
+) -> Box<dyn Fn(Object, &BaubleContext)> {
+    Box::new(move |object, ctx| {
+        let result = T::from_bauble(object.value, &bauble::DefaultAllocator);
+        let read_value = bauble::print_errors(result, ctx).unwrap();
+        assert_eq!(&read_value, &expected_value);
+    })
+}
+
+struct TestFile {
+    path: TypePath,
+    content: String,
+    expected_values: Vec<Box<dyn Fn(Object, &BaubleContext)>>,
+}
+
+macro_rules! test_file {
+    ($path:expr, $content:expr, $($expected_value:expr),* $(,)?) => {
+        TestFile {
+            path: TypePath::new(String::from($path)).unwrap(),
+            content: String::from($content),
+            expected_values: vec![$(expected_value_fn($expected_value)),*],
+        }
+    };
+}
+
+fn test_reload(
+    register_types: &dyn Fn(&mut bauble::BaubleContextBuilder),
+    start: &[&TestFile],
+    new: &[&TestFile],
+) {
+    // Test that parsed objects convert into typed values that match the provided test values.
+    let compare_objects = |objects: Vec<Object>, files: &[&TestFile], ctx: &BaubleContext| {
+        let mut objects = objects.into_iter();
+        for test_value in files.iter().flat_map(|f| &f.expected_values) {
+            let object = objects.next().expect("Not as many objects as test expects");
+            test_value(object, ctx);
+        }
+
+        if objects.next().is_some() {
+            panic!("More objects than test expects");
+        }
+    };
+
+    let mut ctx = bauble::BaubleContextBuilder::new();
+    register_types(&mut ctx);
+    let mut ctx = ctx.build();
+    ctx.type_registry()
+        .validate(true)
+        .expect("Invalid type registry");
+
+    // Test initial parsing from source
+    for file in start {
+        ctx.register_file(file.path.borrow(), &file.content); // format!("\n{}\n", inner_content));
+    }
+
+    let (objects, errors) = ctx.load_all();
+    if !errors.is_empty() {
+        bauble::print_errors(Err::<(), _>(errors), &ctx);
+        panic!("Error converting");
+    }
+    compare_objects(objects, start, &ctx);
+
+    // Test reloading with new content and new files that are nested as submodules.
+    let (objects, errors) = ctx.reload_paths(new.iter().map(|f| (f.path.borrow(), &f.content)));
+    if !errors.is_empty() {
+        bauble::print_errors(Err::<(), _>(errors), &ctx);
+        panic!("Error converting reload");
+    }
+    compare_objects(objects, new, &ctx);
+}
+
+#[test]
+fn new_nested_reload_paths() {
+    let a = &test_file!(
+        "a",
+        r#"test = integration::Test { x: -5, y: 5 }"#,
+        Test { x: -5, y: 5 },
+    );
+
+    let new_a = &test_file!(
+        "a",
+        r#"test = integration::Test { x: -15, y: 15 }"#,
+        Test { x: -15, y: 15 },
+    );
+    let new_ab = &test_file!(
+        "a::b",
+        r#"test = integration::Test { x: -3, y: 3 }"#,
+        Test { x: -3, y: 3 },
+    );
+    let new_abc = &test_file!(
+        "a::b::c",
+        r#"test = integration::Test { x: -4, y: 1 }"#,
+        Test { x: -4, y: 1 },
+    );
+
+    let test = |start: &_, new: &_| {
+        test_reload(
+            &|ctx| {
+                ctx.register_type::<Test, _>();
+            },
+            start,
+            new,
+        )
+    };
+
+    test(&[a], &[new_a]);
+    test(&[a], &[a, new_ab]);
+    test(&[a], &[new_a, new_ab, new_abc]);
+    test(&[a], &[new_a, new_abc, new_ab]);
+}

--- a/bauble/tests/integration.rs
+++ b/bauble/tests/integration.rs
@@ -121,3 +121,15 @@ fn new_nested_reload_paths() {
     test(&[a], &[new_a, new_ab, new_abc]);
     test(&[a], &[new_a, new_abc, new_ab]);
 }
+
+#[test]
+fn duplicate_objects() {
+    // TODO: would be better for this to fail rather than taking the last object? What if the
+    // objects are different types and something references the first one?
+    bauble::bauble_test!(
+        [Test]
+        "test = integration::Test{ x: -5, y: 5 }\n\
+        test = integration::Test{ x: -5, y: 4 }"
+        [Test { x: -5, y: 4 }]
+    );
+}

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+# work around https://github.com/rust-lang/rust.vim/issues/528
+edition = "2024"


### PR DESCRIPTION
These are various changes I made while reading the code (or in response to notes I made while reading the code).

For various bits of behavior I wanted to understand and bugs I wanted confirm before fixing I added some new tests.

### Summary of changes

#### Bug fixes

* Fixed bug in `reload_paths` in certain cases where new files prefixed by existing paths would overwrite the existing file.
* Fixed bug in `reload_files` where some files failing to load would lead to a mismatch in iteration over file IDs and file values.

#### Method reworks

* Rename `CtxNode::filter` to `CtxNode::iter_all_children` and have the caller use `Iterator::filter` instead of taking a `filter` closure. This separates iterating all children and the filtering logic, which should make the logic more clear to readers.
* Rename `CtxNode::walk`/`walk_mut` to `CtxNode::node_at`/`node_at_mut` and remove closure parameter. Instead return node reference that caller can use. Again this separate the concern of getting the node and doing things with it. In some cases this takes more lines, but it uses the `Option` methods familiar to many. Additionally, in one case this avoids needing to re-get the actual node.
* Rename `ref_kinds` to `refs_of_kind` since it returns references of a specific kind rather than a list of kinds.

#### Misc

* Documentation added to various methods and types.
* Removed a few type aliases that were only used in a few places. IMO avoiding layers of indirection outweighs the benefits of aliases in these cases.
* Minor improvements to `bauble_test` macro.
* Remove unused `default_uses` parameter in `value::register_assets`.
* Add TODOs to a couple places that may need further investigation.