### PR TITLE
Produce error for duplicate object names

### DIFF
--- a/bauble/src/parse/parser.rs
+++ b/bauble/src/parse/parser.rs
@@ -631,7 +631,7 @@ pub fn parser<'a>() -> impl Parser<'a, ParserSource<'a>, ParseValues, Extra<'a>>
             .repeated()
             .collect::<Vec<_>>(),
     )
-    .map(|(uses, values)| {
+    .validate(|(uses, values), _, emitter| {
         values.into_iter().fold(
             ParseValues {
                 uses,
@@ -642,6 +642,12 @@ pub fn parser<'a>() -> impl Parser<'a, ParserSource<'a>, ParseValues, Extra<'a>>
                 let binding = Binding { type_path, value };
                 match ty {
                     ItemType::Value => {
+                        if values.values.contains_key(&ident) {
+                            emitter.emit(Rich::custom(
+                                ident.span,
+                                "This identifier was already used".to_string(),
+                            ));
+                        }
                         values.values.insert(ident, binding);
                     }
                     ItemType::Copy => {


### PR DESCRIPTION
Can be merged after https://github.com/Cakefish/bauble/pull/49

Previously the value from the last defined object was used. Now we produce an error.

```
Error: Parser error
   ╭─[ a:2:1 ]
   │
 2 │ test = integration::Test{ x: -5, y: 4 }
   │ ──┬─
   │   ╰─── This identifier was already used
───╯
```