### PR TITLE
Fix referenceable assets being placed into Symbols with the wrong type.

### DIFF
--- a/bauble/src/context.rs
+++ b/bauble/src/context.rs
@@ -497,9 +497,12 @@ impl BaubleContext {
     /// Registers an asset. This is done automatically for any objects in a file that gets registered.
     ///
     /// With this method you can expose assets that aren't in bauble.
-    pub fn register_asset(&mut self, path: TypePath<&str>, ty: TypeId) {
+    ///
+    /// Returns ID of internal Ref type for `ty`.
+    pub fn register_asset(&mut self, path: TypePath<&str>, ty: TypeId) -> TypeId {
         let ref_ty = self.registry.get_or_register_asset_ref(ty);
         self.root_node.build_asset(path, ref_ty);
+        ref_ty
     }
 
     fn file(&self, file: FileId) -> (TypePath<&str>, &Source) {


### PR DESCRIPTION
Sequenced after https://github.com/Cakefish/bauble/pull/50

The code looking for the referenced value expects the type to already be the Ref version rather than the inner type and this is how it is registered into the `CtxNode` tree. So only the entry in Symbols did not align. This caused the new `same_file_reference` test to fail.

Also, add tests for a few other cases that don't currently work when referencing other assets.