### PR TITLE
Remove copy values feature

### DIFF
--- a/bauble/src/parse/value.rs
+++ b/bauble/src/parse/value.rs
@@ -174,5 +174,4 @@ pub struct Binding {
 pub struct ParseValues {
     pub uses: Vec<Spanned<PathTreeNode>>,
     pub values: IndexMap<Ident, Binding>,
-    pub copies: IndexMap<Ident, Binding>,
 }

--- a/bauble/src/value/display.rs
+++ b/bauble/src/value/display.rs
@@ -735,36 +735,6 @@ impl<CTX: ValueCtx<ParseVal>> IndentedDisplay<CTX> for ParseValues {
             written = true;
         }
 
-        let mut iter = self.copies.iter();
-
-        if let Some((ident, binding)) = iter.next() {
-            if written {
-                w.write("\n\n");
-            }
-
-            w.write("copy ");
-            w.write(ident);
-            if let Some(ty) = &binding.type_path {
-                w.write(": ");
-                w.fmt(ty);
-            }
-            w.write(" = ");
-            binding.value.indented_display(w.reborrow());
-        }
-
-        for (ident, binding) in iter {
-            w.write("\n\n");
-
-            w.write("copy ");
-            w.write(ident);
-            if let Some(ty) = &binding.type_path {
-                w.write(": ");
-                w.fmt(ty);
-            }
-            w.write(" = ");
-            binding.value.indented_display(w.reborrow());
-        }
-
         let mut iter = self.values.iter();
 
         if let Some((ident, binding)) = iter.next() {

--- a/bauble_macros/tests/derive.rs
+++ b/bauble_macros/tests/derive.rs
@@ -116,17 +116,14 @@ fn test_std_types() {
     bauble_test!(
         [Test]
         r#"
-        copy key = "🔑"
-        copy value = Some("💖")
-
         test = derive::Test {
             a: [(2, 0), (1, -1), (5, 10)],
             b: {
-                $key: [true, true, false],
+                "🔑": [true, true, false],
                 "no key": [false, true],
             },
             c: {
-                [1, 2, 3]: [$value, None, Some("hi")],
+                [1, 2, 3]: [Some("💖"), None, Some("hi")],
             },
         }
         "#
@@ -141,6 +138,31 @@ fn test_std_types() {
                     ([1, 2, 3], [Some("💖".to_string()), None, Some("hi".to_string())]),
                 ]),
             },
+        ]
+    );
+}
+
+#[test]
+fn test_complex_flatten() {
+    #[derive(Bauble, PartialEq, Debug)]
+    #[bauble(flatten)]
+    struct Inner(
+        u32,
+        #[bauble(attribute = a, default)] u32,
+        #[bauble(attribute = b)] u32,
+    );
+
+    #[derive(Bauble, PartialEq, Debug)]
+    #[bauble(flatten)]
+    struct Transparent(Inner, #[bauble(attribute = a)] u32);
+
+    bauble_test!(
+        [Transparent]
+        r#"
+        a: derive::Transparent = #[a = 1, b = 2] 3
+        "#
+        [
+            Transparent(Inner(3, 0, 2), 1),
         ]
     );
 }


### PR DESCRIPTION
Sequenced after https://github.com/Cakefish/bauble/pull/52

This removes the Copy values feature. Copy values aren't preserved when converting objects back to the Bauble format. Additionally, they have unexpected interactions with sub-objects because the sub-objects aren't duplicated with the outer copy value. Removing this also allows simplifying the logic here.