### PR TITLE
Refactored ambiguous use of `is_writable` into two methods

### DIFF
--- a/bauble/src/context.rs
+++ b/bauble/src/context.rs
@@ -184,7 +184,8 @@ impl BaubleContextBuilder {
             root_node.add_node(id.borrow()).reference.redirect = Some(path);
         }
         for id in self.registry.type_ids() {
-            if self.registry.key_type(id).meta.path.is_writable() {
+            // Only build nodes for types which can actually be written out in Bauble.
+            if self.registry.key_type(id).meta.path.is_representable_type() {
                 root_node.build_type(id, &self.registry);
             }
         }

--- a/bauble/src/types/path.rs
+++ b/bauble/src/types/path.rs
@@ -415,13 +415,17 @@ impl<S: AsRef<str>> TypePath<S> {
                     == Some(PATH_SEPERATOR))
     }
 
-    /// Returns true if this type path is something that is allowed to be
-    /// written in the bauble format.
+    /// Returns true if this type path, referencing a type, is something that is
+    /// allowed to be parsed by Bauble.
+    ///
+    /// Certain paths to types may be unparsable to Bauble yet valid internally,
+    /// therefore this method is useful to make that distinction. An example of
+    /// this are array and tuple types.
     ///
     /// This means that:
     /// - The path is non-empty.
     /// - All the path segments are valid rust identifiers.
-    pub fn is_writable(&self) -> bool {
+    pub fn is_representable_type(&self) -> bool {
         !self.is_empty()
             && self.iter().all(|part| {
                 let mut s = part.as_str().chars();
@@ -431,6 +435,15 @@ impl<S: AsRef<str>> TypePath<S> {
                     .is_ident_start()
                     && s.all(|c| c.is_ident_continue())
             })
+    }
+
+    /// Determines if a path referencing an object is a path to a sub-object.
+    /// The path is assumed to be valid.
+    ///
+    /// This means that:
+    /// - The path contains the special '@' sub-object character.
+    pub fn is_subobject(&self) -> bool {
+        self.iter().any(|part| part.as_str().contains('@'))
     }
 }
 

--- a/bauble/src/value/display.rs
+++ b/bauble/src/value/display.rs
@@ -456,7 +456,7 @@ impl IndentedDisplay<ValueDisplayCtx<'_, UnspannedVal>> for UnspannedVal {
         let path = w
             .ctx()
             .types
-            .get_writable_path(self.ty)
+            .get_representable_path(self.ty)
             .unwrap_or_default()
             .to_owned();
 
@@ -510,7 +510,7 @@ impl IndentedDisplay<ValueDisplayCtx<'_, Val>> for Val {
         let path = w
             .ctx()
             .types
-            .get_writable_path(*self.ty)
+            .get_representable_path(*self.ty)
             .unwrap_or_default()
             .to_owned();
 
@@ -591,7 +591,7 @@ impl<CTX: ValueCtx<V>, V: IndentedDisplay<CTX> + ValueTrait> IndentedDisplay<CTX
                     _ => false,
                 };
 
-            if !can_skip_type && let Some(path) = registry.get_writable_path(ty) {
+            if !can_skip_type && let Some(path) = registry.get_representable_path(ty) {
                 let path = path.to_owned();
                 w.write(": ");
                 w.write(path.as_str());
@@ -655,8 +655,7 @@ where
         let mut inlined_refs = HashMap::new();
         let objects = w.ctx().1;
         for object in objects.iter() {
-            // !is_writable indicates this is a sub-object
-            if !object.object_path.is_writable() {
+            if object.object_path.is_subobject() {
                 inlined_refs.insert(object.object_path.borrow(), &object.value);
             }
         }
@@ -678,7 +677,7 @@ where
         let mut inlined_refs = HashMap::new();
         let mut written = Vec::new();
         for object in self.iter() {
-            if object.object_path.is_writable() {
+            if !object.object_path.is_subobject() {
                 written.push(object);
             } else {
                 inlined_refs.insert(object.object_path.borrow(), &object.value);


### PR DESCRIPTION
As the title says, it removes the `is_writable` method in favour of two separate methods checking for either if the a type is representable in bauble or is a subobject.