### PR TITLE
Asset per file scheme, stage 1

### DIFF
--- a/bauble/src/context.rs
+++ b/bauble/src/context.rs
@@ -431,7 +431,7 @@ impl CtxNode {
     fn build_asset(&mut self, path: TypePath<&str>, ty: TypeId) {
         let node = self.build_nodes(path);
         if node.reference.asset.is_some() {
-            panic!("Multiple types with the same path");
+            panic!("Multiple assets with the same path");
         }
 
         node.reference.asset = Some(ty);

--- a/bauble/src/lib.rs
+++ b/bauble/src/lib.rs
@@ -110,7 +110,7 @@ pub mod private {
             let mut error_msg = errors.try_to_string(&ctx.read().unwrap()).unwrap();
             for (path, re_source) in re_path_sources {
                 use std::fmt::Write;
-                writeln!(&mut error_msg, "In file \"{path}\": {re_source}").unwrap();
+                writeln!(&mut error_msg, "In file \"{path}\":\n{re_source}").unwrap();
             }
             panic!("Error re-converting: \n{error_msg}");
         }

--- a/bauble/src/lib.rs
+++ b/bauble/src/lib.rs
@@ -15,7 +15,7 @@ pub mod types;
 pub use bauble_macros::Bauble;
 
 pub use builtin::Ref;
-pub use context::{BaubleContext, BaubleContextBuilder, FileId, PathReference, Source};
+pub use context::{AssetKind, BaubleContext, BaubleContextBuilder, FileId, PathReference, Source};
 pub use error::{BaubleError, BaubleErrors, CustomError, Level};
 pub use spanned::{Span, SpanExt, Spanned};
 pub use traits::{

--- a/bauble/src/parse/parser.rs
+++ b/bauble/src/parse/parser.rs
@@ -681,13 +681,19 @@ pub fn parser<'a>() -> impl Parser<'a, ParserSource<'a>, ParseValues, Extra<'a>>
             .collect::<Vec<_>>(),
     )
     .validate(|(uses, values), _, emitter| {
-        values.into_iter().fold(
+        values.into_iter().enumerate().fold(
             ParseValues {
                 uses,
                 values: IndexMap::default(),
             },
-            |mut values, (ident, type_path, value)| {
-                let binding = Binding { type_path, value };
+            |mut values, (i, (ident, type_path, value))| {
+                let is_first = i == 0;
+
+                let binding = Binding {
+                    type_path,
+                    value,
+                    is_first,
+                };
 
                 if values.values.contains_key(&ident) {
                     emitter.emit(Rich::custom(

--- a/bauble/src/parse/value.rs
+++ b/bauble/src/parse/value.rs
@@ -168,6 +168,7 @@ impl SpannedValue for ParseVal {
 pub struct Binding {
     pub type_path: Option<Path>,
     pub value: ParseVal,
+    pub is_first: bool,
 }
 
 #[derive(Debug)]

--- a/bauble/src/types.rs
+++ b/bauble/src/types.rs
@@ -726,7 +726,7 @@ impl TypeRegistry {
         }
     }
 
-    /// Register `T` if it is not registerted already, then get the trait ID for `T`.
+    /// Register `T` if it is not registered already, then get the trait ID for `T`.
     pub fn get_or_register_trait<T: ?Sized + BaubleTrait>(&mut self) -> TraitId {
         let rust_id = std::any::TypeId::of::<T>();
         if let Some(id) = self.type_from_rust.get(&rust_id) {

--- a/bauble/src/types.rs
+++ b/bauble/src/types.rs
@@ -586,11 +586,16 @@ impl TypeRegistry {
                 for (name, value) in additonal.into_objects() {
                     objects.push(crate::Object {
                         object_path: file.join(&name),
+                        top_level: false,
                         value,
                     })
                 }
 
-                objects.push(crate::Object { object_path, value })
+                objects.push(crate::Object {
+                    object_path,
+                    top_level: false,
+                    value,
+                })
             }
 
             // Check that instantiated objects match after being serialized to bauble text and

--- a/bauble/src/types.rs
+++ b/bauble/src/types.rs
@@ -248,6 +248,9 @@ impl Display for TypeSystemError<'_> {
 }
 
 impl TypeRegistry {
+    /// The path of the builtin in generic `Ref<_>` type without the generics.
+    pub const REF_TYPE_PATH: &str = "Ref";
+
     /// This is not performant and should not be exposed API, it is used for tests.
     #[doc(hidden)]
     pub fn find_rust_type(&self, ty: TypeId) -> Option<std::any::TypeId> {
@@ -429,8 +432,12 @@ impl TypeRegistry {
                 this.asset_refs.insert(inner, id);
                 let ty = Type {
                     meta: TypeMeta {
-                        path: TypePath::new(format!("Ref<{}>", this.key_type(inner).meta.path))
-                            .expect("Invariant"),
+                        path: TypePath::new(format!(
+                            "{}<{}>",
+                            Self::REF_TYPE_PATH,
+                            this.key_type(inner).meta.path
+                        ))
+                        .expect("Invariant"),
                         traits: this.key_type(inner).meta.traits.clone(),
                         ..Default::default()
                     },

--- a/bauble/src/types/path.rs
+++ b/bauble/src/types/path.rs
@@ -380,11 +380,15 @@ impl<S: AsRef<str>> TypePath<S> {
     }
 
     /// Split the start segment with the remaining segments.
+    ///
+    /// Returns `None` if self is empty.
     pub fn get_start(&self) -> Option<(TypePathElem<&str>, TypePath<&str>)> {
         self.borrow().split_start()
     }
 
     /// Split the end segment with the remaining segments.
+    ///
+    /// Returns `None` if self is empty.
     pub fn get_end(&self) -> Option<(TypePath<&str>, TypePathElem<&str>)> {
         self.borrow().split_end()
     }

--- a/bauble/src/value/convert.rs
+++ b/bauble/src/value/convert.rs
@@ -6,12 +6,10 @@ use crate::{
     path::{TypePath, TypePathElem},
     spanned::{SpanExt, Spanned},
     types::{self, TypeId},
-    value::Fields,
-};
-
-use super::{
-    Attributes, Ident, Result, SpannedValue, Symbols, UnspannedVal, Val, Value, ValueContainer,
-    ValueTrait,
+    value::{
+        Attributes, Fields, Ident, SpannedValue, Symbols, UnspannedVal, Val, Value, ValueContainer,
+        ValueTrait, error::Result,
+    },
 };
 
 pub fn no_attr() -> Option<&'static Attributes<Val>> {

--- a/bauble/src/value/convert.rs
+++ b/bauble/src/value/convert.rs
@@ -344,7 +344,7 @@ impl NameAllocs<'_> {
         }
     }
 
-    /// Allocate a new name for an object that will be referenced by the parnet object
+    /// Allocate a new name for an object that will be referenced by the parent object
     /// `object_name`.
     fn allocate_name(&mut self, object_name: TypePathElem<&str>) -> TypePathElem {
         let from_map = |m: &mut HashMap<TypePathElem, u64>| {

--- a/bauble/src/value/convert.rs
+++ b/bauble/src/value/convert.rs
@@ -257,7 +257,7 @@ impl ConvertMeta<'_> {
 /// Also known as sub-assets.
 pub(super) struct AdditionalObjects {
     objects: Vec<super::Object>,
-    name_allocs: std::collections::HashMap<TypePathElem, u64>,
+    name_allocs: HashMap<TypePathElem, u64>,
     file_path: TypePath,
 }
 
@@ -329,12 +329,12 @@ impl AdditionalObjects {
 }
 
 enum NameAllocs<'a> {
-    Owned(std::collections::HashMap<TypePathElem, u64>),
-    Borrowed(&'a mut std::collections::HashMap<TypePathElem, u64>),
+    Owned(HashMap<TypePathElem, u64>),
+    Borrowed(&'a mut HashMap<TypePathElem, u64>),
 }
 
 impl NameAllocs<'_> {
-    fn get_mut(&mut self) -> &mut std::collections::HashMap<TypePathElem, u64> {
+    fn get_mut(&mut self) -> &mut HashMap<TypePathElem, u64> {
         match self {
             NameAllocs::Owned(m) => m,
             NameAllocs::Borrowed(m) => m,
@@ -357,7 +357,7 @@ impl<'a> AdditionalUnspannedObjects<'a> {
             file_path,
             object_name,
             objects: Vec::new(),
-            name_allocs: NameAllocs::Owned(std::collections::HashMap::default()),
+            name_allocs: NameAllocs::Owned(HashMap::default()),
         }
     }
 

--- a/bauble/src/value/display.rs
+++ b/bauble/src/value/display.rs
@@ -500,6 +500,8 @@ impl IndentedDisplay<ValueDisplayCtx<'_, Val>> for Val {
             w.write(" ");
         }
 
+        // If the type is transparent over a trait type or a ref to a trait type, then the concrete
+        // type of the inner value will not be apparent from the outer context, so `typed` is false.
         let typed = match w.ctx().types.key_type(*self.ty).kind {
             TypeKind::Transparent(t) | TypeKind::Ref(t) => {
                 !matches!(w.ctx().types.key_type(t).kind, TypeKind::Trait(_))
@@ -516,6 +518,7 @@ impl IndentedDisplay<ValueDisplayCtx<'_, Val>> for Val {
 
         let mut w = w.with_type(path.as_str());
 
+        // If we are not in a typed context the type may need to be explicitly specified.
         if !w.is_typed()
             && !path.is_empty()
             && match w.ctx().types.key_type(*self.ty).kind {

--- a/bauble/src/value/symbols.rs
+++ b/bauble/src/value/symbols.rs
@@ -331,8 +331,8 @@ impl<'a> Symbols<'a> {
     pub fn resolve_asset(&self, path: &Path) -> Result<(TypeId, TypePath)> {
         let item = self.resolve_item(path, RefKind::Asset)?.into_owned();
 
-        if let Some(asset) = item.asset {
-            Ok(asset)
+        if let Some((ty, path, _kind)) = item.asset {
+            Ok((ty, path))
         } else {
             Err(ConversionError::RefError(Box::new(RefError {
                 uses: Some(self.uses.clone()),

--- a/bauble/src/value/symbols.rs
+++ b/bauble/src/value/symbols.rs
@@ -329,30 +329,34 @@ impl<'a> Symbols<'a> {
     }
 
     pub fn resolve_asset(&self, path: &Path) -> Result<(TypeId, TypePath)> {
-        let item = self.resolve_item(path, RefKind::Asset)?;
+        let item = self.resolve_item(path, RefKind::Asset)?.into_owned();
 
-        item.asset.clone().ok_or(
-            ConversionError::RefError(Box::new(RefError {
+        if let Some(asset) = item.asset {
+            Ok(asset)
+        } else {
+            Err(ConversionError::RefError(Box::new(RefError {
                 uses: Some(self.uses.clone()),
                 path: self.resolve_path(path)?.value,
-                path_ref: item.into_owned(),
+                path_ref: item,
                 kind: RefKind::Asset,
             }))
-            .spanned(path.span()),
-        )
+            .spanned(path.span()))
+        }
     }
 
     pub fn resolve_type(&self, path: &Path) -> Result<TypeId> {
         let item = self.resolve_item(path, RefKind::Type)?;
 
-        item.ty.ok_or(
-            ConversionError::RefError(Box::new(RefError {
+        if let Some(ty) = item.ty {
+            Ok(ty)
+        } else {
+            Err(ConversionError::RefError(Box::new(RefError {
                 uses: Some(self.uses.clone()),
                 path: self.resolve_path(path)?.value,
                 path_ref: item.into_owned(),
                 kind: RefKind::Type,
             }))
-            .spanned(path.span()),
-        )
+            .spanned(path.span()))
+        }
     }
 }

--- a/bauble/tests/integration.rs
+++ b/bauble/tests/integration.rs
@@ -680,10 +680,11 @@ fn name_matching_file_is_simplified() {
         TestRef("a::c".into()),
     );
 
-    test_load(
+    test_reload(
         &|ctx| {
             ctx.register_type::<Test, _>();
         },
+        &[a, ac, b],
         &[a, ac, b],
     );
 }

--- a/bauble/tests/integration.rs
+++ b/bauble/tests/integration.rs
@@ -391,20 +391,20 @@ fn reference_with_use() {
 pub fn ref_implicit_type() {
     bauble::bauble_test!(
         [Test]
-        "test = integration::Test{ x: -5, y: 5 }\n\
-        r = $test"
+        "t = integration::Test{ x: -5, y: 5 }\n\
+        r = $t"
         [
             Test { x: -5, y: 5 },
-            Ref::<Test>::from_path(TypePath::new_unchecked("test::test").to_owned()),
+            Ref::<Test>::from_path(TypePath::new_unchecked("test::t").to_owned()),
         ]
     );
 
     bauble::bauble_test!(
         [Test]
-        "r = $test::test\n\
-        test = integration::Test{ x: -5, y: 5 }"
+        "r = $test::t\n\
+        t = integration::Test{ x: -5, y: 5 }"
         [
-            Ref::<Test>::from_path(TypePath::new_unchecked("test::test").to_owned()),
+            Ref::<Test>::from_path(TypePath::new_unchecked("test::t").to_owned()),
             Test { x: -5, y: 5 },
         ]
     );
@@ -414,20 +414,20 @@ pub fn ref_implicit_type() {
 pub fn ref_explicit_type() {
     bauble::bauble_test!(
         [Test]
-        "test = integration::Test{ x: -2, y: 2 }\n\
-        r: Ref<integration::Test> = $test"
+        "t = integration::Test{ x: -2, y: 2 }\n\
+        r: Ref<integration::Test> = $t"
         [
             Test { x: -2, y: 2 },
-            Ref::<Test>::from_path(TypePath::new_unchecked("test::test").to_owned()),
+            Ref::<Test>::from_path(TypePath::new_unchecked("test::t").to_owned()),
         ]
     );
 
     bauble::bauble_test!(
         [Test]
-        "r: Ref<integration::Test> = $test::test\n\
-        test = integration::Test{ x: -2, y: 2 }"
+        "r: Ref<integration::Test> = $test::t\n\
+        t = integration::Test{ x: -2, y: 2 }"
         [
-            Ref::<Test>::from_path(TypePath::new_unchecked("test::test").to_owned()),
+            Ref::<Test>::from_path(TypePath::new_unchecked("test::t").to_owned()),
             Test { x: -2, y: 2 },
         ]
     );
@@ -438,23 +438,23 @@ pub fn ref_explicit_type_multiple_files() {
     bauble::bauble_test!(
         [Test]
         [
-            "test = integration::Test{ x: -5, y: 5 }",
-            "r: Ref<integration::Test> = $test0::test"
+            "t = integration::Test{ x: -5, y: 5 }",
+            "r: Ref<integration::Test> = $test0::t"
         ]
         [
             Test { x: -5, y: 5 },
-            Ref::<Test>::from_path(TypePath::new_unchecked("test0::test").to_owned()),
+            Ref::<Test>::from_path(TypePath::new_unchecked("test0::t").to_owned()),
         ]
     );
 
     bauble::bauble_test!(
         [Test]
         [
-            "r: Ref<integration::Test> = $test1::test",
-            "test = integration::Test{ x: -5, y: 5 }"
+            "r: Ref<integration::Test> = $test1::t",
+            "t = integration::Test{ x: -5, y: 5 }"
         ]
         [
-            Ref::<Test>::from_path(TypePath::new_unchecked("test1::test").to_owned()),
+            Ref::<Test>::from_path(TypePath::new_unchecked("test1::t").to_owned()),
             Test { x: -5, y: 5 },
         ]
     );
@@ -465,23 +465,23 @@ pub fn ref_implicit_type_multiple_files() {
     bauble::bauble_test!(
         [Test]
         [
-            "test = integration::Test{ x: -5, y: 5 }",
-            "r = $test0::test"
+            "t = integration::Test{ x: -5, y: 5 }",
+            "r = $test0::t"
         ]
         [
             Test { x: -5, y: 5 },
-            Ref::<Test>::from_path(TypePath::new_unchecked("test0::test").to_owned()),
+            Ref::<Test>::from_path(TypePath::new_unchecked("test0::t").to_owned()),
         ]
     );
 
     bauble::bauble_test!(
         [Test]
         [
-            "r = $test1::test",
-            "test = integration::Test{ x: -5, y: 5 }"
+            "r = $test1::t",
+            "t = integration::Test{ x: -5, y: 5 }"
         ]
         [
-            Ref::<Test>::from_path(TypePath::new_unchecked("test1::test").to_owned()),
+            Ref::<Test>::from_path(TypePath::new_unchecked("test1::t").to_owned()),
             Test { x: -5, y: 5 },
         ]
     );
@@ -496,11 +496,11 @@ pub fn ref_explicit_type_incorrect() {
     bauble::bauble_test!(
         [Test, Incorrect]
         "i: Incorrect = Incorrect(0)\n\
-        r: Ref<Incorrect> = $test::test\n\
-        test = integration::Test{ x: -2, y: 2 }"
+        r: Ref<Incorrect> = $test::t\n\
+        t = integration::Test{ x: -2, y: 2 }"
         [
             Incorrect(0),
-            Ref::<Test>::from_path(TypePath::new_unchecked("test::test").to_owned()),
+            Ref::<Test>::from_path(TypePath::new_unchecked("test::t").to_owned()),
             Test { x: -2, y: 2 },
         ]
     );
@@ -627,3 +627,41 @@ fn two_part_field() {
         &[a],
     );
 }
+
+#[test]
+fn name_matching_file_is_simplified() {
+    let a = &test_file!(
+        "a",
+        "a = integration::Test { x: -5, y: 5 }
+        a_ref = $a", // local and full path are the same here
+        Test { x: -5, y: 5 },
+        TestRef("a".into()),
+    );
+    // test non-top-level file
+    let ac = &test_file!(
+        "a::c",
+        "c = integration::Test { x: -5, y: 5 }\n\
+        c_ref_local = $c\n\
+        c_ref_full = $a::c",
+        Test { x: -5, y: 5 },
+        TestRef("a::c".into()),
+        TestRef("a::c".into()),
+    );
+    // test refering to them from a separate file
+    let b = &test_file!(
+        "b",
+        "a_ref = $a\n\
+         c_ref = $a::c",
+        TestRef("a".into()),
+        TestRef("a::c".into()),
+    );
+
+    test_load(
+        &|ctx| {
+            ctx.register_type::<Test, _>();
+        },
+        &[a, ac, b],
+    );
+}
+
+// TODO: in stage 2, test that only first object can be named `0`.

--- a/bauble_macro_util/src/lib.rs
+++ b/bauble_macro_util/src/lib.rs
@@ -433,7 +433,7 @@ fn parse_fields(
                                     let ident = meta.input.parse::<Ident>()?;
                                     attribute = Some(ident);
                                 } else {
-                                    attribute = Some(field.ident.clone().ok_or(meta.error("For unnamed fields the attribute specifier needs to be annotated with `attribute = ident`"))?);
+                                    attribute = Some(field.ident.clone().ok_or_else(|| meta.error("For unnamed fields the attribute specifier needs to be annotated with `attribute = ident`"))?);
                                 }
 
                                 Ok(())

--- a/bauble_macros/tests/derive.rs
+++ b/bauble_macros/tests/derive.rs
@@ -14,7 +14,7 @@ fn test_struct() {
     bauble_test!(
         [Test]
         r#"
-        test = derive::Test { x: -5, y: 5, z: Some(true) }
+        a = derive::Test { x: -5, y: 5, z: Some(true) }
         "#
         [Test {
             x: -5,
@@ -31,7 +31,7 @@ fn test_tuple() {
 
     bauble_test!(
         [Test]
-        "test = derive::Test(-5, 5)"
+        "a = derive::Test(-5, 5)"
         [Test(-5, 5)]
     );
 }
@@ -116,7 +116,7 @@ fn test_std_types() {
     bauble_test!(
         [Test]
         r#"
-        test = derive::Test {
+        a = derive::Test {
             a: [(2, 0), (1, -1), (5, 10)],
             b: {
                 "🔑": [true, true, false],


### PR DESCRIPTION
This is "stage 1" in converting bauble to a file per top level asset scheme.

Additionally there are changes to support having our bauble editor work with local assets instead of inline assets.

### Asset per file

If an object appears first in the file and its name matches the file's name, its path will now be simplified to the path of the file. Additionally, the object will be marked as `top_level` (via a new field on `Object` and as a property available on assets in `PathReference`).

### Custom naming for additional objects 

We add `AdditionalUnspannedObjects::new_with_custom_namer`. `AdditionalUnspannedObjects` is used when creating new values that need to also create additional objects that they reference. This new method allows custom names instead of creating all new referenced objects as inline sub-objects.

### Misc changes

Removed newline at the beginning of `display_formatted` output and added a newline at the end. Now files generated with this will have a trailing newline.

Exposed constant used for the builtin `Ref` type's path so external code can reliably identify the builtin `Ref` type.