### PR TITLE
Toolchain update and misc improvements

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: nightly-2025-02-25
+        toolchain: nightly-2026-06-05
         override: true
         components: rustfmt,clippy
 

--- a/bauble/src/lib.rs
+++ b/bauble/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc = include_str!("../../OVERVIEW.md")]
-#![feature(iterator_try_collect, let_chains, ptr_metadata)]
+#![feature(iterator_try_collect, ptr_metadata)]
 #![warn(missing_docs)]
 
 mod builtin;

--- a/bauble/src/parse/parser.rs
+++ b/bauble/src/parse/parser.rs
@@ -139,26 +139,6 @@ impl<'a, T> From<TextExpected<'a>> for chumsky::error::RichPattern<'a, T> {
     }
 }
 
-#[derive(Clone, Copy)]
-struct State<T>(T);
-
-impl<'src, T: Copy, I: Input<'src>> chumsky::inspector::Inspector<'src, I> for State<T> {
-    type Checkpoint = State<T>;
-    #[inline(always)]
-    fn on_token(&mut self, _: &<I as Input<'src>>::Token) {}
-    #[inline(always)]
-    fn on_save<'parse>(&self, _: &chumsky::input::Cursor<'src, 'parse, I>) -> Self::Checkpoint {
-        *self
-    }
-    #[inline(always)]
-    fn on_rewind<'parse>(
-        &mut self,
-        c: &chumsky::input::Checkpoint<'src, 'parse, I, Self::Checkpoint>,
-    ) {
-        *self = *c.inspector();
-    }
-}
-
 // TODO Re-add error recovery
 pub fn parser<'a>() -> impl Parser<'a, ParserSource<'a>, ParseValues, Extra<'a>> {
     let line_comment_end = just::<_, ParserSource<'a>, Extra<'a>>('\n').or(end().map(|_| '\0'));

--- a/bauble/src/parse/value.rs
+++ b/bauble/src/parse/value.rs
@@ -147,7 +147,7 @@ impl ValueTrait for ParseVal {
         &self.value
     }
 
-    fn to_any(&self) -> AnyVal {
+    fn to_any(&self) -> AnyVal<'_> {
         AnyVal::Parse(self)
     }
 }

--- a/bauble/src/traits.rs
+++ b/bauble/src/traits.rs
@@ -7,7 +7,7 @@ use crate::{
     object_path::ObjectPath,
     path::{TypePath, TypePathElem},
     spanned::{Span, Spanned},
-    types::{self, Extra, FieldType, TypeId},
+    types::{self, DefaultMaker, Extra, FieldType, TypeId},
     value::{Ident, PrimitiveValue},
 };
 
@@ -312,7 +312,9 @@ impl<'a, A: BaubleAllocator<'a>> Bauble<'a, A> for Val {
             meta: types::TypeMeta {
                 path: TypePath::new("bauble::Val").unwrap().to_owned(),
                 attributes: types::NamedFields::any(),
-                default: Some(|_, _, _| UnspannedVal::new(Value::default())),
+                default: Some(DefaultMaker::new(|_, _, _| {
+                    UnspannedVal::new(Value::default())
+                })),
                 ..Default::default()
             },
             kind: types::TypeKind::Primitive(types::Primitive::Any),
@@ -650,7 +652,7 @@ impl<'a, A: BaubleAllocator<'a>, T: Bauble<'a, A>> Bauble<'a, A> for Option<T> {
                 ))
                 .unwrap(),
                 generic_base_type: Some(generic),
-                default: Some(|a, registry, ty| {
+                default: Some(DefaultMaker::new(|a, registry, ty| {
                     let none = match &registry.key_type(ty).kind {
                         types::TypeKind::Enum { variants } => variants
                             .get("None")
@@ -667,7 +669,7 @@ impl<'a, A: BaubleAllocator<'a>, T: Bauble<'a, A>> Bauble<'a, A> for Option<T> {
                                 .expect("We should be able to instantiate unit fields"),
                         ),
                     ))
-                }),
+                })),
                 ..Default::default()
             },
             kind: types::TypeKind::Enum { variants },

--- a/bauble/src/traits.rs
+++ b/bauble/src/traits.rs
@@ -471,7 +471,7 @@ impl Bauble<'_> for String {
     fn from_bauble(
         val: Val,
         _: &DefaultAllocator,
-    ) -> Result<<DefaultAllocator as BaubleAllocator>::Out<Self>, ToRustError> {
+    ) -> Result<<DefaultAllocator as BaubleAllocator<'_>>::Out<Self>, ToRustError> {
         if let Value::Primitive(PrimitiveValue::Str(str)) = val.value.value {
             Ok(str)
         } else {
@@ -740,7 +740,7 @@ impl<'a, T: Bauble<'a>> Bauble<'a> for Vec<T> {
     fn from_bauble(
         val: Val,
         allocator: &DefaultAllocator,
-    ) -> Result<<DefaultAllocator as BaubleAllocator>::Out<Self>, ToRustError> {
+    ) -> Result<<DefaultAllocator as BaubleAllocator<'_>>::Out<Self>, ToRustError> {
         if let Value::Array(items) = val.value.value {
             items
                 .into_iter()
@@ -775,7 +775,7 @@ impl<'a, T: Bauble<'a>> Bauble<'a> for Box<T> {
     fn from_bauble(
         val: Val,
         allocator: &DefaultAllocator,
-    ) -> Result<<DefaultAllocator as BaubleAllocator>::Out<Self>, ToRustError> {
+    ) -> Result<<DefaultAllocator as BaubleAllocator<'_>>::Out<Self>, ToRustError> {
         T::from_bauble(val, allocator).map(Box::new)
     }
 }
@@ -809,7 +809,7 @@ macro_rules! impl_map {
             fn from_bauble(
                 val: Val,
                 allocator: &DefaultAllocator,
-            ) -> Result<<DefaultAllocator as BaubleAllocator>::Out<Self>, ToRustError> {
+            ) -> Result<<DefaultAllocator as BaubleAllocator<'_>>::Out<Self>, ToRustError> {
                 if let Value::Map(map) = val.value.value {
                     map.into_iter()
                         .map(|(k, v)| {

--- a/bauble/src/types.rs
+++ b/bauble/src/types.rs
@@ -23,7 +23,7 @@ use crate::{
     value::UnspannedVal,
 };
 
-#[allow(missing_docs)]
+/// Type associated data that can be given to a registered type, variant, or field.
 pub type Extra = IndexMap<String, String>;
 
 /// A trait that can be represented within a bauble context.

--- a/bauble/src/types.rs
+++ b/bauble/src/types.rs
@@ -1019,6 +1019,8 @@ impl TypeRegistry {
                         .iter_type_set(tr)
                         // The transparent type may itself implement the trait, so we need to skip
                         // it to avoid an infinite loop.
+                        // TODO: are there cases for other type kinds where this may happen? E.g. a
+                        // random struct with a trait (or reference to a trait) as a field?
                         .filter(|ty| *ty != ty_id)
                         .collect();
                     v.sort_unstable_by(|a, b| {

--- a/bauble/src/types.rs
+++ b/bauble/src/types.rs
@@ -193,6 +193,15 @@ impl Variant {
     }
 }
 
+/// Error details for when the instantiated value of a type is not identical after roundtripping
+/// through the Bauble format.
+#[derive(Debug)]
+pub struct ConstructInequalityError {
+    src: String,
+    original: UnspannedVal,
+    new: UnspannedVal,
+}
+
 /// An error that occured within the Bauble context's type-system during [`TypeRegister::validate`].
 #[allow(missing_docs)]
 #[derive(Debug)]
@@ -203,7 +212,8 @@ pub enum TypeSystemError<'a> {
         ty: TypePath<&'a str>,
     },
     InstantiableErrors,
-    ConstructInequality(String, UnspannedVal, UnspannedVal),
+    // This variant is large, so we box it.
+    ConstructInequality(Box<ConstructInequalityError>),
     MissingObjects {
         instantiated_missing: Vec<ObjectPath>,
         loaded_unknown: Vec<ObjectPath>,
@@ -232,11 +242,12 @@ impl Display for TypeSystemError<'_> {
                 f,
                 "Errors while trying to read default instantiated objects"
             ),
-            TypeSystemError::ConstructInequality(s, a, b) => {
+            TypeSystemError::ConstructInequality(e) => {
+                let ConstructInequalityError { src, original, new } = &**e;
                 write!(
                     f,
                     "The constructed instantiated type, and the value read from the instantiated \
-                    value formatted as text are not equal.\nBauble:\n{s}\n\nInstantiated: {a:#?}\nRead: {b:#?}"
+                    value formatted as text are not equal.\nBauble:\n{src}\n\nInstantiated: {original:#?}\nRead: {new:#?}"
                 )
             }
             TypeSystemError::MissingObjects {
@@ -660,7 +671,11 @@ impl TypeRegistry {
                             .skip(span.start)
                             .take(span.end - span.start)
                             .collect();
-                        TypeSystemError::ConstructInequality(src, original, new)
+                        TypeSystemError::ConstructInequality(Box::new(ConstructInequalityError {
+                            src,
+                            original,
+                            new,
+                        }))
                     } else {
                         TypeSystemError::MissingObjects {
                             instantiated_missing: missing

--- a/bauble/src/types.rs
+++ b/bauble/src/types.rs
@@ -551,7 +551,7 @@ impl TypeRegistry {
     /// Currently this checks:
     /// - Are there any unassigned registered types?
     /// - If `assert_instanciable` is true then if all `instanciable` types have valid bauble representations.
-    pub fn validate(&self, assert_instanciable: bool) -> Result<(), TypeSystemError> {
+    pub fn validate(&self, assert_instanciable: bool) -> Result<(), TypeSystemError<'_>> {
         if !self.to_be_assigned.is_empty() {
             return Err(TypeSystemError::ToBeAssigned(
                 self.to_be_assigned

--- a/bauble/src/types.rs
+++ b/bauble/src/types.rs
@@ -403,7 +403,7 @@ impl TypeRegistry {
                                 attributes: variant.attributes,
                                 extra: variant.extra,
                                 extra_validation: variant.extra_validation,
-                                default: variant.default,
+                                default: variant.default.map(DefaultMaker::new),
                                 ..Default::default()
                             },
                             kind: match variant.kind {
@@ -574,7 +574,6 @@ impl TypeRegistry {
                     // If the path is not writable then it cannot be validated
                     // as it cannot be written out as Bauble source.
                     || !ty.meta.path.is_representable_type()
-                    || !ty.meta.traits.contains(&self.object_trait_dependency)
                 {
                     continue;
                 }
@@ -593,6 +592,15 @@ impl TypeRegistry {
                         ty: ty.meta.path.borrow(),
                     });
                 };
+
+                // Value can't be deserialized to object if it doesn't impl the object trait, so
+                // skip converting these to the bauble text format and back.
+                //
+                // We check this after `instantiate`, so we can test the instantiation code for
+                // more types even if a full serialization roundtrip is not tested).
+                if !self.impls_object_trait(value.ty) {
+                    continue;
+                }
 
                 for (path, value) in additonal.into_objects() {
                     objects.push(crate::Object {
@@ -905,6 +913,11 @@ impl TypeRegistry {
     }
 
     /// Create the default value of this type.
+    ///
+    /// The returned value will be assigned a `TypeId` that is for a type where
+    /// `TypeKind::instanciable` is `true`. In most cases this matches the `ty_id` provided to
+    /// `instantiate`. For trait types this is instead the `ty_id` of the type instiantiated that
+    /// implements the trait.
     pub fn instantiate(
         &self,
         ty_id: TypeId,
@@ -913,7 +926,7 @@ impl TypeRegistry {
         let ty = self.key_type(ty_id);
 
         if let Some(default) = &ty.meta.default {
-            return Some(default(additional_objects, self, ty_id).with_type(ty_id));
+            return Some(default.make_value(additional_objects, self, ty_id));
         }
 
         let construct_unnamed =
@@ -1002,7 +1015,19 @@ impl TypeRegistry {
             TypeKind::Transparent(ty) => {
                 let inner = self.key_type(*ty);
                 crate::Value::Transparent(Box::new(if let TypeKind::Trait(tr) = &inner.kind {
-                    self.iter_type_set(tr)
+                    let mut v: Vec<_> = self
+                        .iter_type_set(tr)
+                        // The transparent type may itself implement the trait, so we need to skip
+                        // it to avoid an infinite loop.
+                        .filter(|ty| *ty != ty_id)
+                        .collect();
+                    v.sort_unstable_by(|a, b| {
+                        self.key_type(*a)
+                            .meta
+                            .path
+                            .cmp(&self.key_type(*b).meta.path)
+                    });
+                    v.into_iter()
                         .find_map(|ty| self.instantiate(ty, additional_objects))?
                 } else {
                     self.instantiate(*ty, additional_objects)?
@@ -1051,6 +1076,32 @@ pub type ValidationFunction =
 pub type DefaultFunction =
     fn(&mut AdditionalUnspannedObjects, &TypeRegistry, TypeId) -> UnspannedVal;
 
+/// Wrapper around `DefaultFunction` that ensures the returned value is properly assigned a
+/// concrete type ID.
+#[derive(Clone, Copy, Debug)]
+pub struct DefaultMaker(DefaultFunction);
+
+impl DefaultMaker {
+    /// Creates a new `DefaultMaker` wrapping the provided `DefaultFunction`.
+    pub fn new(f: DefaultFunction) -> Self {
+        Self(f)
+    }
+
+    /// See [`DefaultFunction`] docs.
+    pub fn make_value(
+        &self,
+        additional: &mut AdditionalUnspannedObjects,
+        types: &TypeRegistry,
+        ty: TypeId,
+    ) -> UnspannedVal {
+        // Default values not allowed for non-instanciable types.
+        debug_assert!(types.key_type(ty).kind.instanciable());
+        let mut value = (self.0)(additional, types, ty);
+        value.ty = ty;
+        value
+    }
+}
+
 /// Meta information on a type registered within a Bauble context.
 #[derive(Default, Clone, Debug)]
 pub struct TypeMeta {
@@ -1061,7 +1112,7 @@ pub struct TypeMeta {
     /// The traits implemented by the type.
     pub traits: Vec<TraitId>,
     /// Optional function to create a default value of the type.
-    pub default: Option<DefaultFunction>,
+    pub default: Option<DefaultMaker>,
     /// What attributes the type expects.
     pub attributes: NamedFields,
     /// If this type has any extra invariants that need to be checked.

--- a/bauble/src/types/path.rs
+++ b/bauble/src/types/path.rs
@@ -167,10 +167,17 @@ impl<S: AsRef<str>> std::fmt::Display for TypePath<S> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PathError {
     /// There was an empty path element, for example `foo::::bar`.
+    ///
+    /// Contains byte index where path element was expected to start, just after the starting '::'
+    /// for that path element. This index may be right after the end of the string.
     EmptyElem(usize),
-    /// A start delimiter, i.e `<`, `(`, `[`, is missing its end equivalent.
+    /// A start delimiter, i.e `<`, `(`, `[`, `{`, is missing its end equivalent.
+    ///
+    /// Contains byte index of start delimiter character.
     MissingDelimiterEnd(usize),
-    /// An end delimiter, i.e `>`, `)`, `]`, is missing its start equivalent.
+    /// An end delimiter, i.e `>`, `)`, `]`, `}`, is missing its start equivalent.
+    ///
+    /// Contains byte index of end delimiter character.
     MissingDelimiterStart(usize),
     /// Too many path elements.
     ///
@@ -219,23 +226,25 @@ fn path_len(path: &str) -> Result<usize> {
         return Ok(0);
     }
 
-    let mut count = 1;
-    let mut current_path_delim = PATH_SEPERATOR.chars();
+    let mut count = 0;
+    // When this iterator is empty, we expect to an encounter a path element, and not
+    // the start of PATH_SEPERATOR. A path must start with a path element, so this starts as an
+    // empty iterator.
+    let mut current_path_delim = "".chars();
     let mut path_iter = path.char_indices();
-    let mut is_empty = true;
 
     while let Some((i, c)) = path_iter.next() {
         match current_path_delim.next() {
             Some(expected) => {
                 if c == expected {
                     continue;
-                } else {
-                    is_empty = false;
                 }
             }
             None => {
+                // `c` is the start of a new path element.
                 count += 1;
-                if PATH_SEPERATOR.starts_with(c) || is_empty {
+                // If `c` matches the start of PATH_SEPERATOR, this path element was empty.
+                if PATH_SEPERATOR.starts_with(c) {
                     return Err(PathError::EmptyElem(i));
                 }
             }
@@ -244,6 +253,7 @@ fn path_len(path: &str) -> Result<usize> {
         skip_delims(&mut path_iter, c, i)?;
     }
 
+    // The path ended with PATH_SEPERATOR and no following element.
     if current_path_delim.next().is_none() {
         return Err(PathError::EmptyElem(path.len()));
     }
@@ -722,8 +732,29 @@ fn test_path_seperating() {
         ),
     );
 
-    let error_path = TypePath::new("root(test<)::test::el]em");
-    assert!(error_path.is_err());
+    let error_paths = [
+        "root(test<)::test::elem",
+        "root(test<)::test::el]em",
+        "root(test)::test::el]em",
+        "::",
+        ":::",
+        "::test",
+        ":test",
+        ":",
+        "root:::elem",
+        "root::::elem",
+        "root:::::elem",
+        "root::test::",
+        "root::test:::",
+        "root::test::::",
+        // Note, these are currently allowed:
+        // "test:ing",
+        // "test:in:g",
+        // "root::test:",
+    ];
+    for path in error_paths {
+        assert!(TypePath::new(path).is_err(), "{}", path);
+    }
 
     let empty_path = TypePath::new("").unwrap();
 

--- a/bauble/src/types/path.rs
+++ b/bauble/src/types/path.rs
@@ -394,7 +394,7 @@ impl<S: AsRef<str>> TypePath<S> {
     }
 
     /// Create an iterator for iterating the segments of `self`.
-    pub fn iter(&self) -> PathIter {
+    pub fn iter(&self) -> PathIter<'_> {
         PathIter {
             path: self.borrow(),
         }

--- a/bauble/src/value/convert.rs
+++ b/bauble/src/value/convert.rs
@@ -78,14 +78,14 @@ fn resolve_type(
         }
     };
 
-    if let Some(val_type) = val_type {
-        if !types.can_infer_from(expected_type, val_type.value) {
-            return Err(ConversionError::ExpectedExactType {
-                expected: expected_type,
-                got: Some(val_type.value),
-            }
-            .spanned(span));
+    if let Some(val_type) = val_type
+        && !types.can_infer_from(expected_type, val_type.value)
+    {
+        return Err(ConversionError::ExpectedExactType {
+            expected: expected_type,
+            got: Some(val_type.value),
         }
+        .spanned(span));
     }
 
     Ok(ty)

--- a/bauble/src/value/convert.rs
+++ b/bauble/src/value/convert.rs
@@ -244,7 +244,7 @@ pub struct ConvertMeta<'a> {
 }
 
 impl ConvertMeta<'_> {
-    pub fn reborrow(&mut self) -> ConvertMeta {
+    pub fn reborrow(&mut self) -> ConvertMeta<'_> {
         ConvertMeta {
             symbols: self.symbols,
             additional_objects: self.additional_objects,

--- a/bauble/src/value/convert.rs
+++ b/bauble/src/value/convert.rs
@@ -835,7 +835,7 @@ where
                         |additional| {
                             ty.meta
                                 .default
-                                .map(|v| v(additional, types, *ty_id).into_spanned(span))
+                                .map(|d| d.make_value(additional, types, *ty_id).into_spanned(span))
                                 .expect("We checked that this is some in the match")
                         },
                     )?;

--- a/bauble/src/value/display.rs
+++ b/bauble/src/value/display.rs
@@ -95,7 +95,7 @@ mod formatter {
             write!(&mut self.0.string, "{v:?}").expect("Shouldn't fail");
         }
 
-        pub fn reborrow(&mut self) -> LineWriter<CTX> {
+        pub fn reborrow(&mut self) -> LineWriter<'_, CTX> {
             LineWriter(self.0.reborrow())
         }
 
@@ -122,11 +122,11 @@ mod formatter {
             LineWriter(self.0.with_ctx(ctx))
         }
 
-        pub fn with_typed_context(&mut self) -> LineWriter<CTX> {
+        pub fn with_typed_context(&mut self) -> LineWriter<'_, CTX> {
             LineWriter(self.0.with_typed_context())
         }
 
-        pub fn with_untyped_context(&mut self) -> LineWriter<CTX> {
+        pub fn with_untyped_context(&mut self) -> LineWriter<'_, CTX> {
             LineWriter(self.0.with_untyped_context())
         }
     }
@@ -146,7 +146,7 @@ mod formatter {
                 typed_context: true,
             }
         }
-        fn reborrow(&mut self) -> Formatter<CTX> {
+        fn reborrow(&mut self) -> Formatter<'_, CTX> {
             Formatter {
                 config: self.config,
                 string: self.string,
@@ -156,7 +156,7 @@ mod formatter {
                 typed_context: self.typed_context,
             }
         }
-        fn bump_indent(&mut self) -> Formatter<CTX> {
+        fn bump_indent(&mut self) -> Formatter<'_, CTX> {
             let mut r = self.reborrow();
             r.indent += 1;
             r

--- a/bauble/src/value/display.rs
+++ b/bauble/src/value/display.rs
@@ -589,20 +589,24 @@ impl<CTX: ValueCtx<V>, V: IndentedDisplay<CTX> + ValueTrait> IndentedDisplay<CTX
         w.write(ident);
 
         if let Some(registry) = w.ctx().type_registry() {
-            let ty = self.value.ty();
+            let ty_id = self.value.ty();
+            let ty = registry.key_type(ty_id);
+            let is_generic_instance = ty.meta.generic_base_type.is_some();
             // We can skip displaying the type path if the value hints what type it should be. This
             // is the case for non-flattened structs and enums, and primitive types.
-            let can_skip_type = registry.is_primitive_type(ty)
-                || match &registry.key_type(ty).kind {
+            //
+            // The value may not be sufficient for generic enums so those are not skipped. For
+            // example, the value `Option::None` contains no hint at what the generic type
+            // parameter should be.
+            let can_skip_type = registry.is_primitive_type(ty_id)
+                || match &ty.kind {
                     TypeKind::Struct(_) => true,
-                    TypeKind::Enum { variants } => {
+                    TypeKind::Enum { variants } if !is_generic_instance => {
                         if let Value::Enum(variant, _) = self.value.value()
                             && let Some(variant_ty) = variants.get(variant.borrow())
+                            && let TypeKind::EnumVariant { .. } = registry.key_type(variant_ty).kind
                         {
-                            matches!(
-                                registry.key_type(variant_ty).kind,
-                                TypeKind::EnumVariant { .. }
-                            )
+                            true
                         } else {
                             false
                         }
@@ -611,7 +615,7 @@ impl<CTX: ValueCtx<V>, V: IndentedDisplay<CTX> + ValueTrait> IndentedDisplay<CTX
                     _ => false,
                 };
 
-            if !can_skip_type && let Some(path) = registry.get_representable_path(ty) {
+            if !can_skip_type && let Some(path) = registry.get_representable_path(ty_id) {
                 let path = path.to_owned();
                 w.write(": ");
                 w.write(path.as_str());

--- a/bauble/src/value/mod.rs
+++ b/bauble/src/value/mod.rs
@@ -42,7 +42,7 @@ pub trait ValueTrait: Clone + std::fmt::Debug {
 
     fn value(&self) -> &Value<Self>;
 
-    fn to_any(&self) -> AnyVal;
+    fn to_any(&self) -> AnyVal<'_>;
 }
 
 /// A helper trait for extracting the spans out of a Bauble value.
@@ -77,7 +77,7 @@ pub trait ValueContainer: Clone + std::fmt::Debug {
 
     fn container_ty(&self) -> TypeId;
 
-    fn container_to_any(&self) -> AnyVal;
+    fn container_to_any(&self) -> AnyVal<'_>;
 }
 
 impl<V: ValueTrait> ValueContainer for V {
@@ -91,7 +91,7 @@ impl<V: ValueTrait> ValueContainer for V {
         ValueTrait::ty(self)
     }
 
-    fn container_to_any(&self) -> AnyVal {
+    fn container_to_any(&self) -> AnyVal<'_> {
         self.to_any()
     }
 }
@@ -115,7 +115,7 @@ impl ValueContainer for AnyVal<'_> {
         }
     }
 
-    fn container_to_any(&self) -> AnyVal {
+    fn container_to_any(&self) -> AnyVal<'_> {
         *self
     }
 }
@@ -245,7 +245,7 @@ impl ValueTrait for Val {
         &self.value
     }
 
-    fn to_any(&self) -> AnyVal {
+    fn to_any(&self) -> AnyVal<'_> {
         AnyVal::Complete(self)
     }
 }
@@ -345,7 +345,7 @@ impl ValueTrait for UnspannedVal {
         &self.value
     }
 
-    fn to_any(&self) -> AnyVal {
+    fn to_any(&self) -> AnyVal<'_> {
         AnyVal::Unspanned(self)
     }
 }

--- a/bauble/src/value/mod.rs
+++ b/bauble/src/value/mod.rs
@@ -1056,8 +1056,8 @@ fn compare_objects(
     loaded: &UnspannedVal,
     orig_map: &HashMap<ObjectPath, UnspannedVal>,
     loaded_map: &HashMap<ObjectPath, (crate::Span, UnspannedVal)>,
-) -> std::result::Result<(), (UnspannedVal, UnspannedVal)> {
-    let inquality_err = || (original.clone(), loaded.clone());
+) -> std::result::Result<(), Box<(UnspannedVal, UnspannedVal)>> {
+    let inquality_err = || Box::new((original.clone(), loaded.clone()));
 
     original
         .attributes
@@ -1199,7 +1199,7 @@ pub fn compare_object_sets(
         if !matches!(k, ObjectPath::Inline(_)) {
             if let Some((span, b)) = loaded_object_map.get(k) {
                 if let Err((original, new)) =
-                    compare_objects(a, b, &original_object_map, &loaded_object_map)
+                    compare_objects(a, b, &original_object_map, &loaded_object_map).map_err(|e| *e)
                 {
                     mismatched.push((k.to_owned(), *span, original, new));
                 }

--- a/bauble_macro_util/src/lib.rs
+++ b/bauble_macro_util/src/lib.rs
@@ -1258,7 +1258,7 @@ pub fn derive_bauble_derive_input(
         .unwrap_or(quote!(::core::option::Option::None));
 
     let default = match ty_attrs.value_default {
-        Some(e) => quote! { ::core::option::Option::Some(#e) },
+        Some(e) => quote! { ::core::option::Option::Some(::bauble::types::DefaultMaker::new(#e)) },
         None => quote! { ::core::option::Option::None },
     };
 

--- a/bauble_macro_util/src/lib.rs
+++ b/bauble_macro_util/src/lib.rs
@@ -337,7 +337,7 @@ fn parse_fields(
     tuple: bool,
     has_from: bool,
     construct_default: fn(TokenStream) -> TokenStream,
-) -> syn::Result<FieldsInfo> {
+) -> syn::Result<FieldsInfo<'_>> {
     let mut val_count = 0;
     let kind = match fields {
         // Named fields in a type with the `tuple` attribute are treated as a tuple

--- a/bauble_macros/tests/derive.rs
+++ b/bauble_macros/tests/derive.rs
@@ -285,7 +285,7 @@ fn test_trait() {
             val: bauble::Val,
             allocator: &bauble::DefaultAllocator,
         ) -> Result<
-            <bauble::DefaultAllocator as bauble::BaubleAllocator>::Out<Self>,
+            <bauble::DefaultAllocator as bauble::BaubleAllocator<'_>>::Out<Self>,
             bauble::ToRustError,
         > {
             let s = val.span();

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2025-02-25"
+channel = "nightly-2026-06-05"


### PR DESCRIPTION
This bumps the nightly version to keep it in sync with the dreamthorn repo and resolves new lints. This also contains additional improvements that I have added while working on things:

- Add `DefaultMaker` to enforce type ID assignment to instantiated default values
- Minor documentation improvements
- Fix validation object trait check which previously skipped all types when doing validation
- Fix infinite instantiation loop involving traits
- Fix validation of `Option` by writing out explicit types for generic enums